### PR TITLE
Add date, time, datetime custom scalars

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -811,6 +811,11 @@
         "source-map-support": "^0.5.1"
       }
     },
+    "graphql-iso-date": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/graphql-iso-date/-/graphql-iso-date-3.6.1.tgz",
+      "integrity": "sha512-AwFGIuYMJQXOEAgRlJlFL4H1ncFM8n8XmoVDTNypNOZyQ8LFDG2ppMFlsS862BSTCDcSUfHp8PD3/uJhv7t59Q=="
+    },
     "graphql-tools": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-4.0.6.tgz",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "body-parser": "^1.19.0",
     "express": "^4.17.1",
     "graphql": "^14.6.0",
+    "graphql-iso-date": "^3.6.1",
     "graphql-tools": "^4.0.6",
     "lodash": "^4.17.15",
     "nodemon": "^2.0.2",

--- a/schema/user.js
+++ b/schema/user.js
@@ -13,6 +13,8 @@ const userSchema = `
     firstName: String!
     lastName: String!
     email: String!
+    createdAt: DateTime
+    updatedAt: DateTime
   }
   `
 ;

--- a/server.js
+++ b/server.js
@@ -9,7 +9,9 @@ const { eventResolvers } = require('./resolvers/event');
 const express = require('express');
 const bodyParser = require('body-parser');
 const { graphqlExpress, graphiqlExpress } = require('apollo-server-express');
+const { GraphQLDate, GraphQLTime, GraphQLDateTime } = require('graphql-iso-date');
 const { makeExecutableSchema } = require('graphql-tools');
+
 
 const { Sequelize } = require('sequelize');
 
@@ -18,6 +20,12 @@ const PORT = 8080;
 const HOST = '0.0.0.0';
 
 // Schema
+
+const scalars = `
+  scalar Date
+  scalar Time
+  scalar DateTime
+`;
 
 const Query = `
   type Query {
@@ -31,10 +39,16 @@ const Mutation = `
   }
 `;
 
-const resolvers = {};
+const resolvers = {
+  // Custom scalars
+  Date: GraphQLDate,
+  Time: GraphQLTime,
+  DateTime: GraphQLDateTime,
+
+};
 
 const schema = makeExecutableSchema({
-  typeDefs: [ Query, Mutation, userSchema, eventSchema ],
+  typeDefs: [ scalars, Query, Mutation, userSchema, eventSchema ],
   resolvers: merge(resolvers, userResolvers, eventResolvers),
 });
 


### PR DESCRIPTION
## Overview
Allow for date/time/datetime data types when defining schema.

[Notion task](https://www.notion.so/uwblueprintexecs/Add-Date-scalar-graphql-997ef0b0c9cd40c58052ecd26c8f5a1f)

## Changes
* Installed graphql-iso-date
* imported scalars when creating schemas
* add example usage for users

## Screenshots
In the schema, define as so:
<img width="202" alt="image" src="https://user-images.githubusercontent.com/22237453/73787106-975f5680-4768-11ea-9d53-df2b8c954b3b.png">



## Testing
manual testing on graphiql

## Other Notes
* run `npm install` for graphql-iso-date
* I put the schema updates in server.js. At some point, we should move the graphql stuff into another file.

@uwblueprint/paramedics 
