### PR TITLE
Move GraphQL logic to out of server.js

### DIFF
--- a/graphql.js
+++ b/graphql.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const { merge } = require('lodash');
+const { userSchema } = require('./schema/user');
+const { userResolvers } = require('./resolvers/user');
+const { eventSchema } = require('./schema/event');
+const { eventResolvers } = require('./resolvers/event');
+
+const { GraphQLDate, GraphQLTime, GraphQLDateTime } = require('graphql-iso-date');
+const { makeExecutableSchema } = require('graphql-tools');
+
+const scalars = `
+  scalar Date
+  scalar Time
+  scalar DateTime
+`;
+
+const Query = `
+  type Query {
+    _empty: String
+  }
+`;
+
+const Mutation = `
+  type Mutation {
+    _empty: String
+  }
+`;
+
+const resolvers = {
+    // Custom scalars
+    Date: GraphQLDate,
+    Time: GraphQLTime,
+    DateTime: GraphQLDateTime,
+
+};
+
+const schema = makeExecutableSchema({
+    typeDefs: [ scalars, Query, Mutation, userSchema, eventSchema ],
+    resolvers: merge(resolvers, userResolvers, eventResolvers),
+});
+
+exports.schema = schema;

--- a/graphql.js
+++ b/graphql.js
@@ -15,12 +15,14 @@ const scalars = `
   scalar DateTime
 `;
 
+// Base query schema, other queries extend this
 const Query = `
   type Query {
     _empty: String
   }
 `;
 
+// Base mutation schema, other mutations extend this
 const Mutation = `
   type Mutation {
     _empty: String

--- a/server.js
+++ b/server.js
@@ -1,56 +1,13 @@
 'use strict';
 
-const { merge } = require('lodash');
-const { userSchema } = require('./schema/user');
-const { userResolvers } = require('./resolvers/user');
-const { eventSchema } = require('./schema/event');
-const { eventResolvers } = require('./resolvers/event');
-
 const express = require('express');
 const bodyParser = require('body-parser');
 const { graphqlExpress, graphiqlExpress } = require('apollo-server-express');
-const { GraphQLDate, GraphQLTime, GraphQLDateTime } = require('graphql-iso-date');
-const { makeExecutableSchema } = require('graphql-tools');
-
-
-const { Sequelize } = require('sequelize');
+const { schema } = require('./graphql');
 
 // Constants
 const PORT = 8080;
 const HOST = '0.0.0.0';
-
-// Schema
-
-const scalars = `
-  scalar Date
-  scalar Time
-  scalar DateTime
-`;
-
-const Query = `
-  type Query {
-    _empty: String
-  }
-`;
-
-const Mutation = `
-  type Mutation {
-    _empty: String
-  }
-`;
-
-const resolvers = {
-  // Custom scalars
-  Date: GraphQLDate,
-  Time: GraphQLTime,
-  DateTime: GraphQLDateTime,
-
-};
-
-const schema = makeExecutableSchema({
-  typeDefs: [ scalars, Query, Mutation, userSchema, eventSchema ],
-  resolvers: merge(resolvers, userResolvers, eventResolvers),
-});
 
 // App
 const app = express();


### PR DESCRIPTION
## Overview
Keeps `server.js` tidy by removing graphql logic

[Notion task](https://www.notion.so/uwblueprintexecs/refactor-server-js-49fb5caaa7c341439f76efb56f0a9281)

## Changes
Adds `graphql.js` and moves graphql related logic there from server.js
