### PR TITLE
fix bug where builder only runs in prod

### DIFF
--- a/build/builder/builder.cc
+++ b/build/builder/builder.cc
@@ -86,9 +86,9 @@ int main(int argc, char *argv[]){
 	Logger & logger = Logger::getLogger();
 
 	if (input_mode == DEFAULT_OPTION_MODE) {
-		mode = DEPLOY_STATE::PROD;
-	} else {
 		mode = DEPLOY_STATE::DEV;
+	} else {
+		mode = DEPLOY_STATE::PROD;
 	}
 
 	if (input_exec == "") {


### PR DESCRIPTION
## Overview
As described in title. (thank you @lazypanda10117  :))

## Changes
There was a bug where another flag was dependent on DEFAULT_OPTION_MODE

## Testing
manual testing

@uwblueprint/paramedics 
