### PR TITLE
Fix container breaking on prod

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -22,7 +22,7 @@ RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 COPY . ./
 
-EXPOSE 8080
+EXPOSE 4000
 
 # Discourage tampering
 ENTRYPOINT [ "npm" , "run", "prod" ]

--- a/config/config.json
+++ b/config/config.json
@@ -17,11 +17,12 @@
     "operatorsAliases": false
   },
   "production": {
-    "username": "root",
-    "password": null,
-    "database": "database_production",
-    "host": "127.0.0.1",
-    "dialect": "mysql",
+    "username": "robot",
+    "password": "robot_pwd",
+    "database": "paramedics-db",
+    "host": "paramedics-db",
+    "port": 5432,
+    "dialect": "postgresql",
     "operatorsAliases": false
   }
 }

--- a/docker-compose-prod.yaml
+++ b/docker-compose-prod.yaml
@@ -9,7 +9,7 @@ services:
       context: .
       dockerfile: Dockerfile.prod
     ports:
-    - "8080:8080"
+    - "4000:4000"
     logging:
       driver: "json-file"
       options:


### PR DESCRIPTION
## Overview
Fixed bug where starting the containers on prod mode causes an error about installing mysql2.

[Notion task](https://www.notion.so/uwblueprintexecs/Prod-is-broken-43cce1dbfed24c75b32ae637a30a081f)

## Changes
- Expose the port 4000 instead of 8080.
- Fix config.json to reflect the right db fields

## Testing
manual testing

## Other Notes
- I pointed the db to the dev db for now, we can change it once we get prod up and running
- interactive graphql won't work in prod by design. it'll say `GET query missing.` instead

@uwblueprint/paramedics 
