### PR TITLE
Created proper associations in collectionPoints table 

### DIFF
--- a/seeders/20200206002553-demo-collectionPoint.js
+++ b/seeders/20200206002553-demo-collectionPoint.js
@@ -4,12 +4,22 @@ const db = require('../models');
 
 module.exports = {
   up: async (queryInterface, Sequelize) => {
+    const user = await db.user.create({
+      firstName: "Firas",
+      lastName: "Mansour",
+      email: "mansour_is_a_cool_guy@gmail.com",
+      password: "asdfgh1234",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    });
 
     const event = await db.event.create({
       eventDate: new Date(),
       name: "St. Patricks",
-      pin: "cool",
-      description: "Cool day"
+      createdBy: user.id,
+      isActive: true,
+      createdAt: new Date(),
+      updatedAt: new Date()
 
     });
       return queryInterface.bulkInsert('collectionPoints', [{


### PR DESCRIPTION
## Overview
I was encountering a bug when I tried to query events:

![90914592_2611892182466532_5249424615331069952_n](https://user-images.githubusercontent.com/21224282/77472362-6949da80-6dd9-11ea-85fe-7fa944645e94.png)

I fixed this bug in this PR

## Changes
Edited the collectionPoints migration so that when a user is created, all proper field that are supposed to be non-null are created (eg. createdBy and isActive field are supposed to be non-null, but were null with this migration). 

## Screenshots
<img width="1423" alt="Screen Shot 2020-03-24 at 2 09 11 PM" src="https://user-images.githubusercontent.com/21224282/77472514-a910c200-6dd9-11ea-98c7-d20a63750214.png">


## Testing
Manual GraphIQL testing

## Other Notes
When we work with migrations, we need to make sure that any users/events or any other object fully complies with the provided schema.

## Checklist
- [x] Change title to be more descriptive (shouldn't be just branch name)
- [x] `Overview`
- [x] `Changes`
- [x] \(Optional) `Screenshots`
- [x] \(Optional) `Testing` (N/A if nothing changed)
- [x] \(Optional) `Other Notes`
- [x] Request at least 2 reviewers
- [x] Assign yourself to the PR
- [x] Make sure build passes

@uwblueprint/paramedics 