### PR TITLE
Run migrations on container start

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "paramedics-web",
+  "license": "UNLICENSED",
   "version": "1.0.0",
   "author": "UW Blueprint",
   "description": "Paramedics API",
@@ -13,7 +14,7 @@
     "dev": "nodemon server.js"
   },
   "dependencies": {
-    "apollo-server": "^2.10.1",
+    "apollo-server": "^2.14.2",
     "body-parser": "^1.19.0",
     "express": "^4.17.1",
     "graphql": "^14.6.0",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "url": "https://github.com/uwblueprint/paramedics-web.git"
   },
   "scripts": {
-    "prod": "node server.js",
-    "dev": "nodemon server.js"
+    "prod": "sequelize db:migrate && node server.js",
+    "dev": "sequelize db:migrate && nodemon server.js"
   },
   "dependencies": {
     "apollo-server": "^2.14.2",


### PR DESCRIPTION
## Overview
>[Code review doc for reference](https://www.notion.so/uwblueprintexecs/Code-Review-a21fc85b00394f488e92d9d605f6b2bc)
- now that we will be doing deploys, we need a way to programatically run migrations instead of doing it manually

[Notion task](https://www.notion.so/uwblueprintexecs/run-migrations-on-container-build-481c5fda813c4b44917b4ff2ee9a9c94)

## Changes
- call `sequelize db:migrate` every time container spins up
- fix a security vulnerability (maybe?) by bumping the `apollo-server` version

## Testing
- undo your most recent migration (`sequelize db:migrate:undo`) and restart your container -> should see that migration be executed in the logs (can also be checked using `sequelize db:migrate:status`)
  - note: this will clobber data you have in your hospitals table, if this is something you want to avoid then creating a new migration would work as well (don't run migrations manually and restart the container)

## Screenshots
