### PR TITLE
Patient schema changes

### DIFF
--- a/migrations/20200707221810-mandatory-patient-fields.js
+++ b/migrations/20200707221810-mandatory-patient-fields.js
@@ -1,0 +1,51 @@
+"use strict";
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction((t) => {
+      return Promise.all([
+        queryInterface.changeColumn("patients", "barcodeValue", {
+          type: Sequelize.BIGINT,
+          allowNull: false,
+        }),
+        queryInterface.sequelize.query(
+          'ALTER TABLE patients ALTER COLUMN "triageLevel" TYPE "enum_patients_triageLevel", ALTER COLUMN "triageLevel" SET NOT NULL'
+        ),
+        // queryInterface.changeColumn("patients", "triageLevel", {
+        //   type: Sequelize.DataTypes.ENUM(
+        //     "WHITE",
+        //     "GREEN",
+        //     "YELLOW",
+        //     "RED",
+        //     "BLACK"
+        //   ),
+        //   allowNull: false,
+        // }),
+      ]);
+    });
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction((t) => {
+      return Promise.all([
+        queryInterface.changeColumn("patients", "barcodeValue", {
+          type: Sequelize.BIGINT,
+          allowNull: true,
+        }),
+        queryInterface.sequelize.query(
+          'ALTER TABLE patients ALTER COLUMN "triageLevel" TYPE "enum_patients_triageLevel", ALTER COLUMN "triageLevel" DROP NOT NULL'
+        ),
+        // queryInterface.changeColumn("patients", "triageLevel", {
+        //   type: Sequelize.DataTypes.ENUM(
+        //     "WHITE",
+        //     "GREEN",
+        //     "YELLOW",
+        //     "RED",
+        //     "BLACK"
+        //   ),
+        //   allowNull: true,
+        // }),
+      ]);
+    });
+  },
+};

--- a/migrations/20200707221810-mandatory-patient-fields.js
+++ b/migrations/20200707221810-mandatory-patient-fields.js
@@ -4,23 +4,19 @@ module.exports = {
   up: (queryInterface, Sequelize) => {
     return queryInterface.sequelize.transaction((t) => {
       return Promise.all([
-        queryInterface.changeColumn("patients", "barcodeValue", {
-          type: Sequelize.BIGINT,
-          allowNull: false,
-        }),
-        queryInterface.sequelize.query(
-          'ALTER TABLE patients ALTER COLUMN "triageLevel" TYPE "enum_patients_triageLevel", ALTER COLUMN "triageLevel" SET NOT NULL'
+        queryInterface.changeColumn(
+          "patients",
+          "barcodeValue",
+          {
+            type: Sequelize.BIGINT,
+            allowNull: false,
+          },
+          { transaction: t }
         ),
-        // queryInterface.changeColumn("patients", "triageLevel", {
-        //   type: Sequelize.DataTypes.ENUM(
-        //     "WHITE",
-        //     "GREEN",
-        //     "YELLOW",
-        //     "RED",
-        //     "BLACK"
-        //   ),
-        //   allowNull: false,
-        // }),
+        queryInterface.sequelize.query(
+          'ALTER TABLE patients ALTER COLUMN "triageLevel" TYPE "enum_patients_triageLevel", ALTER COLUMN "triageLevel" SET NOT NULL',
+          { transaction: t }
+        ),
       ]);
     });
   },
@@ -28,23 +24,19 @@ module.exports = {
   down: (queryInterface, Sequelize) => {
     return queryInterface.sequelize.transaction((t) => {
       return Promise.all([
-        queryInterface.changeColumn("patients", "barcodeValue", {
-          type: Sequelize.BIGINT,
-          allowNull: true,
-        }),
-        queryInterface.sequelize.query(
-          'ALTER TABLE patients ALTER COLUMN "triageLevel" TYPE "enum_patients_triageLevel", ALTER COLUMN "triageLevel" DROP NOT NULL'
+        queryInterface.changeColumn(
+          "patients",
+          "barcodeValue",
+          {
+            type: Sequelize.BIGINT,
+            allowNull: true,
+          },
+          { transaction: t }
         ),
-        // queryInterface.changeColumn("patients", "triageLevel", {
-        //   type: Sequelize.DataTypes.ENUM(
-        //     "WHITE",
-        //     "GREEN",
-        //     "YELLOW",
-        //     "RED",
-        //     "BLACK"
-        //   ),
-        //   allowNull: true,
-        // }),
+        queryInterface.sequelize.query(
+          'ALTER TABLE patients ALTER COLUMN "triageLevel" TYPE "enum_patients_triageLevel", ALTER COLUMN "triageLevel" DROP NOT NULL',
+          { transaction: t }
+        ),
       ]);
     });
   },

--- a/schema/patient.js
+++ b/schema/patient.js
@@ -24,11 +24,11 @@ const patientSchema = `
       gender: String,
       age: Int,
       runNumber: Int,
-      barcodeValue: Int,
+      barcodeValue: Int!,
       collectionPointId: ID!,
       status: status,
       triageCategory: Int,
-      triageLevel: triageLevel, 
+      triageLevel: triageLevel!, 
       notes: String,
       transportTime: DateTime,
     ): Patient!

--- a/schema/patient.js
+++ b/schema/patient.js
@@ -11,6 +11,7 @@ const patientSchema = `
     ON_SITE
     RELEASED
     TRANSPORTED
+    DELETED
   }
 
   extend type Query {
@@ -64,7 +65,5 @@ const patientSchema = `
     createdAt: DateTime,
     updatedAt: DateTime,
   }
-  `
-  ;
-
+  `;
 exports.patientSchema = patientSchema;


### PR DESCRIPTION
## Overview
>[Code review doc for reference](https://www.notion.so/uwblueprintexecs/Code-Review-a21fc85b00394f488e92d9d605f6b2bc)

[Notion task](https://www.notion.so/uwblueprintexecs/396370c5e09f4c28bc7f455a7e84c908?v=3751aa62a2594c74b7e0ecb363304c24&p=91ddc3a4b6574688b7d89bc59adf9dcc)


## Changes
- Added in DELETED field for status enum in `schema/patient.js`
- Added in mandatory barcode and triageLevel fields inline with frontend changes
- Added migration to make barcodeValue and triageLevel in the `patients` table to be non-nullable

## Testing
- Added and edited patients using DELETED status
- Added patients without barcode and triageLevel ensuring that GraphQL threw error
- To test the migration:
    1. Enter the database and run the following SQL command: `SELECT column_name, data_type, is_nullable FROM information_schema.columns WHERE TABLE_NAME='patients';`. This tells you which columns are nullable and non-nullable. Pay attention to `barcodeValue` and `triageLevel`.
    2. Run the migration from the shell
    3. Enter the database and re-run the above SQL command. Notice how the nullability has changed for `barcodeValue` and `triageLevel`. You can retry these steps when you migrate down
