### PR TITLE
Add linting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
       - restore_cache:
           keys:
             - dev-dependencies-{{ checksum "package.json" }}
-              - dev-dependencies-
+            - dev-dependencies-
       - setup_remote_docker:
           docker_layer_caching: false
       - node/with-cache:
@@ -105,8 +105,22 @@ jobs:
           keys:
             - dev-dependencies-{{ checksum "package.json" }}
               - dev-dependencies-
-      - attach_workspace:
-          at: .
+      - setup_remote_docker:
+          docker_layer_caching: false
+      - run:
+          name: Install docker-compose
+          command: |
+            set -x
+            curl -L https://github.com/docker/compose/releases/download/1.12.0/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
+            chmod +x /usr/local/bin/docker-compose
+      - run:
+          name: Add mock env file
+          command: touch paramedics-web.env
+      - run: 
+          name: Start container via docker-compose
+          command: |
+            set -x
+            docker-compose -f docker-compose-dev.yaml up -d
       - run:
           name: Lint files
           command: npm run lint
@@ -125,4 +139,4 @@ workflows:
             - dev-install
       - dev-lint:
           requires:
-            - dev-build
+            - dev-install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,4 @@ workflows:
   version: 2
   build-test:
     jobs:
-      - install
-      - build:
-          requires:
-            - install
+      - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,26 +50,6 @@ jobs:
           paths:
             - node_modules
           key: prod-dependencies-{{ checksum "package.json" }}
-          
-  prod-install:
-    docker:
-      - image: uwbpparamedics/uwblueprint-paramedics-web:0.0.1
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - prod-dependencies-{{ checksum "package.json" }}
-              - prod-dependencies-
-      - setup_remote_docker:
-          docker_layer_caching: false
-      - node/with-cache:
-          steps:
-            - run: npm install
-      - save_cache:
-          paths:
-            - node_modules
-          key: prod-dependencies-{{ checksum "package.json" }}
-
 
   
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,6 +90,9 @@ jobs:
       - run:
           name: Building image
           command: docker build -t uwbpparamedics/uwblueprint-paramedics-web:0.0.1 -f Dockerfile.dev .
+      - run:
+          name: Add mock env file
+          command: touch paramedics-web.env
       - run: 
           name: Start container via docker-compose
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,6 +104,4 @@ workflows:
   dev-build:
     jobs:
       - dev-build
-      - dev-lint:
-          requires:
-            - dev-build
+      - dev-lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
           name: Building image
           command: docker build -t uwbpparamedics/uwblueprint-paramedics-web:0.0.1 -f Dockerfile.prod .
       - run: 
-          name: Run Docker compose
+          name: Start container via docker-compose
           command: |
             set -x
             docker-compose -f docker-compose-prod.yaml up -d
@@ -50,13 +50,61 @@ jobs:
           paths:
             - node_modules
           key: prod-dependencies-{{ checksum "package.json" }}
+          
+  dev-install:
+    docker:
+      - image: uwbpparamedics/uwblueprint-paramedics-web:0.0.1
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - dev-dependencies-{{ checksum "package.json" }}
+              - dev-dependencies-
+      - setup_remote_docker:
+          docker_layer_caching: false
+      - node/with-cache:
+          steps:
+            - run: npm install
+      - save_cache:
+          paths:
+            - node_modules
+          key: dev-dependencies-{{ checksum "package.json" }}
 
+  dev-build:
+    docker: 
+      - image: uwbpparamedics/uwblueprint-paramedics-web:0.0.1
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - dev-dependencies-{{ checksum "package.json" }}
+            - dev-dependencies-
+      - setup_remote_docker:
+          docker_layer_caching: false
+      - run:
+          name: Install docker-compose
+          command: |
+            set -x
+            curl -L https://github.com/docker/compose/releases/download/1.12.0/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
+            chmod +x /usr/local/bin/docker-compose
+      - run:
+          name: Building image
+          command: docker build -t uwbpparamedics/uwblueprint-paramedics-web:0.0.1 -f Dockerfile.dev .
+      - run: 
+          name: Start container via docker-compose
+          command: |
+            set -x
+            docker-compose -f docker-compose-dev.yaml up -d
+      - save_cache:
+          paths:
+            - node_modules
+          key: dev-dependencies-{{ checksum "package.json" }}
   
 workflows:
   version: 2
-  prod-build:
+  dev-build:
     jobs:
-      - prod-install
-      - prod-build:
+      - dev-install
+      - dev-build:
           requires:
-            - prod-install
+            - dev-install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,10 +7,6 @@ jobs:
       - image: uwbpparamedics/uwblueprint-paramedics-web:0.0.1
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - prod-dependencies-{{ checksum "package.json" }}
-            - prod-dependencies-
       - setup_remote_docker:
           docker_layer_caching: false
       - run:
@@ -24,20 +20,12 @@ jobs:
           command: |
             set -x
             docker-compose -f docker-compose-prod.yaml up -d
-      - save_cache:
-          paths:
-            - node_modules
-          key: prod-dependencies-{{ checksum "package.json" }}
 
   dev-build:
     docker: 
       - image: uwbpparamedics/uwblueprint-paramedics-web:0.0.1
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - dev-dependencies-{{ checksum "package.json" }}
-            - dev-dependencies-
       - setup_remote_docker:
           docker_layer_caching: false
       - run:
@@ -54,19 +42,11 @@ jobs:
           command: |
             set -x
             docker-compose -f docker-compose-dev.yaml up -d
-      - save_cache:
-          paths:
-            - node_modules
-          key: dev-dependencies-{{ checksum "package.json" }}
   dev-lint:
     docker: 
       - image: uwbpparamedics/uwblueprint-paramedics-web:0.0.1
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - dev-dependencies-{{ checksum "package.json" }}
-            - dev-dependencies-
       - node/with-cache:
           steps:
             - run: npm install
@@ -75,14 +55,10 @@ jobs:
       - run:
           name: Lint files
           command: npm run lint
-      - save_cache:
-          paths:
-            - node_modules
-          key: dev-dependencies-{{ checksum "package.json" }}
 
 workflows:
   version: 2
-  dev-build:
+  build-and-lint:
     jobs:
       - prod-build
       - dev-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,9 +88,6 @@ jobs:
             curl -L https://github.com/docker/compose/releases/download/1.12.0/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
             chmod +x /usr/local/bin/docker-compose
       - run:
-          name: Building image
-          command: docker build -t uwbpparamedics/uwblueprint-paramedics-web:0.0.1 -f Dockerfile.dev .
-      - run:
           name: Add mock env file
           command: touch paramedics-web.env
       - run: 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,25 +47,6 @@ jobs:
           paths:
             - node_modules
           key: prod-dependencies-{{ checksum "package.json" }}
-          
-  dev-install:
-    docker:
-      - image: uwbpparamedics/uwblueprint-paramedics-web:0.0.1
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - dev-dependencies-{{ checksum "package.json" }}
-            - dev-dependencies-
-      - setup_remote_docker:
-          docker_layer_caching: false
-      - node/with-cache:
-          steps:
-            - run: npm install
-      - save_cache:
-          paths:
-            - node_modules
-          key: dev-dependencies-{{ checksum "package.json" }}
 
   dev-build:
     docker: 
@@ -122,10 +103,7 @@ workflows:
   version: 2
   dev-build:
     jobs:
-      - dev-install
-      - dev-build:
-          requires:
-            - dev-install
+      - dev-build
       - dev-lint:
           requires:
             - dev-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,12 +11,17 @@ jobs:
           keys:
             - v1-dependencies-{{ checksum "package.json" }}
               - v1-dependencies-
+      - setup_remote_docker:
+          docker_layer_caching: false
+      - node/with-cache:
+          steps:
+            - run: npm install
       - save_cache:
           paths:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
 
-  build:
+  prod-build:
     docker: 
       - image: uwbpparamedics/uwblueprint-paramedics-web:0.0.1
     steps:
@@ -25,9 +30,6 @@ jobs:
           keys:
             - v1-dependencies-{{ checksum "package.json" }}
             - v1-dependencies-
-      - node/with-cache:
-          steps:
-            - run: npm install
       - setup_remote_docker:
           docker_layer_caching: false
       - run:
@@ -53,4 +55,7 @@ workflows:
   version: 2
   build-test:
     jobs:
-      - build
+      - install
+      - prod-build:
+        - requires:
+          - install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,23 +104,12 @@ jobs:
       - restore_cache:
           keys:
             - dev-dependencies-{{ checksum "package.json" }}
-              - dev-dependencies-
-      - setup_remote_docker:
-          docker_layer_caching: false
-      - run:
-          name: Install docker-compose
-          command: |
-            set -x
-            curl -L https://github.com/docker/compose/releases/download/1.12.0/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
-            chmod +x /usr/local/bin/docker-compose
-      - run:
-          name: Add mock env file
-          command: touch paramedics-web.env
-      - run: 
-          name: Start container via docker-compose
-          command: |
-            set -x
-            docker-compose -f docker-compose-dev.yaml up -d
+            - dev-dependencies-
+      - node/with-cache:
+          steps:
+            - run: npm install
+      - attach_workspace:
+          at: .
       - run:
           name: Lint files
           command: npm run lint
@@ -139,4 +128,4 @@ workflows:
             - dev-install
       - dev-lint:
           requires:
-            - dev-install
+            - dev-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 orbs:
   node: circleci/node@1.1.6
 jobs:
-  install:
+  prod-install:
     docker:
       - image: uwbpparamedics/uwblueprint-paramedics-web:0.0.1
     steps:
@@ -53,9 +53,9 @@ jobs:
   
 workflows:
   version: 2
-  build-test:
+  prod-build:
     jobs:
-      - install
+      - prod-install
       - prod-build:
           requires:
-            - install
+            - prod-install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,9 +38,6 @@ jobs:
             set -x
             curl -L https://github.com/docker/compose/releases/download/1.12.0/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
             chmod +x /usr/local/bin/docker-compose
-      - run:
-          name: Building image
-          command: docker build -t uwbpparamedics/uwblueprint-paramedics-web:0.0.1 -f Dockerfile.prod .
       - run: 
           name: Start container via docker-compose
           command: |
@@ -99,7 +96,25 @@ jobs:
           paths:
             - node_modules
           key: dev-dependencies-{{ checksum "package.json" }}
-  
+  dev-lint:
+    docker: 
+      - image: uwbpparamedics/uwblueprint-paramedics-web:0.0.1
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - dev-dependencies-{{ checksum "package.json" }}
+              - dev-dependencies-
+      - attach_workspace:
+          at: .
+      - run:
+          name: Lint files
+          command: npm run lint
+      - save_cache:
+          paths:
+            - node_modules
+          key: dev-dependencies-{{ checksum "package.json" }}
+
 workflows:
   version: 2
   dev-build:
@@ -108,3 +123,6 @@ workflows:
       - dev-build:
           requires:
             - dev-install
+      - dev-lint:
+          requires:
+            - dev-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,5 +57,5 @@ workflows:
     jobs:
       - install
       - prod-build:
-        - requires:
-          - install
+          requires:
+            - install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,8 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "package.json" }}
-              - v1-dependencies-
+            - prod-dependencies-{{ checksum "package.json" }}
+              - prod-dependencies-
       - setup_remote_docker:
           docker_layer_caching: false
       - node/with-cache:
@@ -19,7 +19,7 @@ jobs:
       - save_cache:
           paths:
             - node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}
+          key: prod-dependencies-{{ checksum "package.json" }}
 
   prod-build:
     docker: 
@@ -28,8 +28,8 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "package.json" }}
-            - v1-dependencies-
+            - prod-dependencies-{{ checksum "package.json" }}
+            - prod-dependencies-
       - setup_remote_docker:
           docker_layer_caching: false
       - run:
@@ -49,7 +49,28 @@ jobs:
       - save_cache:
           paths:
             - node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}
+          key: prod-dependencies-{{ checksum "package.json" }}
+          
+  prod-install:
+    docker:
+      - image: uwbpparamedics/uwblueprint-paramedics-web:0.0.1
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - prod-dependencies-{{ checksum "package.json" }}
+              - prod-dependencies-
+      - setup_remote_docker:
+          docker_layer_caching: false
+      - node/with-cache:
+          steps:
+            - run: npm install
+      - save_cache:
+          paths:
+            - node_modules
+          key: prod-dependencies-{{ checksum "package.json" }}
+
+
   
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,25 +2,6 @@ version: 2.1
 orbs:
   node: circleci/node@1.1.6
 jobs:
-  prod-install:
-    docker:
-      - image: uwbpparamedics/uwblueprint-paramedics-web:0.0.1
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - prod-dependencies-{{ checksum "package.json" }}
-              - prod-dependencies-
-      - setup_remote_docker:
-          docker_layer_caching: false
-      - node/with-cache:
-          steps:
-            - run: npm install
-      - save_cache:
-          paths:
-            - node_modules
-          key: prod-dependencies-{{ checksum "package.json" }}
-
   prod-build:
     docker: 
       - image: uwbpparamedics/uwblueprint-paramedics-web:0.0.1
@@ -103,5 +84,6 @@ workflows:
   version: 2
   dev-build:
     jobs:
+      - prod-build
       - dev-build
       - dev-lint

--- a/.eslintrc
+++ b/.eslintrc
@@ -18,6 +18,7 @@
     "import/prefer-default-export": "off",
     "no-shadow": "off",
     "no-plusplus": "off",
-    "react/jsx-curly-newline": "off"
+    "react/jsx-curly-newline": "off",
+    "strict": "off"
   }
 }

--- a/config/config.js
+++ b/config/config.js
@@ -1,26 +1,26 @@
 require('dotenv').config();
 module.exports = {
-  "development": {
-    "username": process.env.PARAMEDICS_DB_USER,
-    "password": process.env.PARAMEDICS_DB_PASSWORD,
-    "database": process.env.PARAMEDICS_DB,
-    "host": process.env.PARAMEDICS_DB_HOST,
-    "port": 5432,
-    "dialect": "postgresql"
+  development: {
+    username: process.env.PARAMEDICS_DB_USER,
+    password: process.env.PARAMEDICS_DB_PASSWORD,
+    database: process.env.PARAMEDICS_DB,
+    host: process.env.PARAMEDICS_DB_HOST,
+    port: 5432,
+    dialect: 'postgresql',
   },
-  "test": {
-    "username": "root",
-    "password": null,
-    "database": "database_test",
-    "host": "127.0.0.1",
-    "dialect": "mysql"
+  test: {
+    username: 'root',
+    password: null,
+    database: 'database_test',
+    host: '127.0.0.1',
+    dialect: 'mysql',
   },
-  "production": {
-    "username": process.env.POSTGRES_USER,
-    "password": process.env.POSTGRES_PASSWORD,
-    "database": process.env.POSTGRES_DB,
-    "host": process.env.POSTGRES_DB_HOST,
-    "port": 5432,
-    "dialect": "postgresql"
-  }
+  production: {
+    username: process.env.POSTGRES_USER,
+    password: process.env.POSTGRES_PASSWORD,
+    database: process.env.POSTGRES_DB,
+    host: process.env.POSTGRES_DB_HOST,
+    port: 5432,
+    dialect: 'postgresql',
+  },
 };

--- a/graphql.js
+++ b/graphql.js
@@ -29,7 +29,6 @@ const scalars = `
   scalar DateTime
 `;
 
-console.log("testing for CI linting");
 // Base query schema, other queries extend this
 const Query = `
   type Query {

--- a/graphql.js
+++ b/graphql.js
@@ -29,6 +29,7 @@ const scalars = `
   scalar DateTime
 `;
 
+console.log("testing for CI linting");
 // Base query schema, other queries extend this
 const Query = `
   type Query {

--- a/graphql.js
+++ b/graphql.js
@@ -1,27 +1,27 @@
-"use strict";
+'use strict';
 
-const { merge } = require("lodash");
-const { userSchema } = require("./schema/user");
-const { userResolvers } = require("./resolvers/user");
-const { eventSchema } = require("./schema/event");
-const { eventResolvers } = require("./resolvers/event");
-const { patientSchema } = require("./schema/patient");
-const { patientResolvers } = require("./resolvers/patient");
-const { collectionPointSchema } = require("./schema/collectionPoint");
-const { collectionPointResolvers } = require("./resolvers/collectionPoint");
-const { hospitalSchema } = require("./schema/hospital");
-const { hospitalResolvers } = require("./resolvers/hospital");
-const { ambulanceSchema } = require("./schema/ambulance");
-const { ambulanceResolvers } = require("./resolvers/ambulance");
-const { locationPinSchema } = require("./schema/locationPin");
-const { locationPinResolvers } = require("./resolvers/locationPin");
+const { merge } = require('lodash');
+const { userSchema } = require('./schema/user');
+const { userResolvers } = require('./resolvers/user');
+const { eventSchema } = require('./schema/event');
+const { eventResolvers } = require('./resolvers/event');
+const { patientSchema } = require('./schema/patient');
+const { patientResolvers } = require('./resolvers/patient');
+const { collectionPointSchema } = require('./schema/collectionPoint');
+const { collectionPointResolvers } = require('./resolvers/collectionPoint');
+const { hospitalSchema } = require('./schema/hospital');
+const { hospitalResolvers } = require('./resolvers/hospital');
+const { ambulanceSchema } = require('./schema/ambulance');
+const { ambulanceResolvers } = require('./resolvers/ambulance');
+const { locationPinSchema } = require('./schema/locationPin');
+const { locationPinResolvers } = require('./resolvers/locationPin');
 
 const {
   GraphQLDate,
   GraphQLTime,
   GraphQLDateTime,
-} = require("graphql-iso-date");
-const { makeExecutableSchema } = require("apollo-server");
+} = require('graphql-iso-date');
+const { makeExecutableSchema } = require('apollo-server');
 
 const scalars = `
   scalar Date

--- a/migrations/20200128012958-create-event.js
+++ b/migrations/20200128012958-create-event.js
@@ -1,33 +1,34 @@
-"use strict";
+'use strict';
+
 module.exports = {
   up: (queryInterface, Sequelize) => {
-    return queryInterface.createTable("events", {
+    return queryInterface.createTable('events', {
       id: {
         allowNull: false,
         autoIncrement: true,
         primaryKey: true,
-        type: Sequelize.INTEGER
+        type: Sequelize.INTEGER,
       },
       name: {
-        type: Sequelize.STRING
+        type: Sequelize.STRING,
       },
       pin: {
-        type: Sequelize.STRING
+        type: Sequelize.STRING,
       },
       description: {
-        type: Sequelize.TEXT
+        type: Sequelize.TEXT,
       },
       createdAt: {
         allowNull: false,
-        type: Sequelize.DATE
+        type: Sequelize.DATE,
       },
       updatedAt: {
         allowNull: false,
-        type: Sequelize.DATE
-      }
+        type: Sequelize.DATE,
+      },
     });
   },
-  down: (queryInterface, Sequelize) => {
-    return queryInterface.dropTable("events");
-  }
+  down: (queryInterface) => {
+    return queryInterface.dropTable('events');
+  },
 };

--- a/migrations/20200128014549-create-user.js
+++ b/migrations/20200128014549-create-user.js
@@ -1,4 +1,5 @@
 'use strict';
+
 module.exports = {
   up: (queryInterface, Sequelize) => {
     return queryInterface.createTable('users', {
@@ -6,42 +7,45 @@ module.exports = {
         allowNull: false,
         autoIncrement: true,
         primaryKey: true,
-        type: Sequelize.INTEGER
+        type: Sequelize.INTEGER,
       },
       accessLevel: {
-        type: Sequelize.DataTypes.ENUM('COMMANDER', 'SUPERVISOR', 'ADMIN')
+        type: Sequelize.DataTypes.ENUM('COMMANDER', 'SUPERVISOR', 'ADMIN'),
       },
       firstName: {
-        type: Sequelize.STRING
+        type: Sequelize.STRING,
       },
       lastName: {
-        type: Sequelize.STRING
+        type: Sequelize.STRING,
       },
       email: {
-        type: Sequelize.STRING
+        type: Sequelize.STRING,
       },
       password: {
-        type: Sequelize.STRING
+        type: Sequelize.STRING,
       },
       emergencyContact: {
-        type: Sequelize.STRING
+        type: Sequelize.STRING,
       },
       createdAt: {
         allowNull: false,
-        type: Sequelize.DATE
+        type: Sequelize.DATE,
       },
       updatedAt: {
         allowNull: false,
-        type: Sequelize.DATE
-      }
+        type: Sequelize.DATE,
+      },
     });
   },
-  down: (queryInterface, Sequelize) => {
-    return queryInterface.sequelize.transaction(t => {
+  down: (queryInterface) => {
+    return queryInterface.sequelize.transaction((t) => {
       return Promise.all([
-        queryInterface.dropTable('users'),
-        queryInterface.sequelize.query('DROP TYPE IF EXISTS "enum_users_accessLevel";')
+        queryInterface.dropTable('users', { transaction: t }),
+        queryInterface.sequelize.query(
+          'DROP TYPE IF EXISTS "enum_users_accessLevel";',
+          { transaction: t }
+        ),
       ]);
-    }); 
-  }
+    });
+  },
 };

--- a/migrations/20200204015426-add-columns-event.js
+++ b/migrations/20200204015426-add-columns-event.js
@@ -1,64 +1,64 @@
-"use strict";
+'use strict';
 
 module.exports = {
   up: (queryInterface, Sequelize) => {
-    return queryInterface.sequelize.transaction(t => {
+    return queryInterface.sequelize.transaction((t) => {
       return Promise.all([
         queryInterface.addColumn(
-          "events",
-          "date",
+          'events',
+          'date',
           {
-            type: Sequelize.DataTypes.STRING
+            type: Sequelize.DataTypes.STRING,
           },
           { transaction: t }
         ),
         queryInterface.addColumn(
-          "events",
-          "createdBy",
+          'events',
+          'createdBy',
           {
-            type: Sequelize.DataTypes.INTEGER
+            type: Sequelize.DataTypes.INTEGER,
           },
           { transaction: t }
         ),
         queryInterface.addColumn(
-          "events",
-          "isActive",
+          'events',
+          'isActive',
           {
-            type: Sequelize.DataTypes.BOOLEAN
+            type: Sequelize.DataTypes.BOOLEAN,
           },
           { transaction: t }
-        )
+        ),
       ]);
     });
   },
   down: (queryInterface, Sequelize) => {
-    return queryInterface.sequelize.transaction(t => {
+    return queryInterface.sequelize.transaction((t) => {
       return Promise.all([
         queryInterface.removeColumn(
-          "events",
-          "date",
+          'events',
+          'date',
           {
-            type: Sequelize.DataTypes.STRING
+            type: Sequelize.DataTypes.STRING,
           },
           { transaction: t }
         ),
         queryInterface.removeColumn(
-          "events",
-          "createdBy",
+          'events',
+          'createdBy',
           {
-            type: Sequelize.DataTypes.INTEGER
+            type: Sequelize.DataTypes.INTEGER,
           },
           { transaction: t }
         ),
         queryInterface.removeColumn(
-          "events",
-          "isActive",
+          'events',
+          'isActive',
           {
-            type: Sequelize.DataTypes.Bool
+            type: Sequelize.DataTypes.Bool,
           },
           { transaction: t }
-        )
+        ),
       ]);
     });
-  }
+  },
 };

--- a/migrations/20200206005201-create-patient.js
+++ b/migrations/20200206005201-create-patient.js
@@ -1,4 +1,5 @@
 'use strict';
+
 module.exports = {
   up: (queryInterface, Sequelize) => {
     return queryInterface.createTable('patients', {
@@ -6,56 +7,68 @@ module.exports = {
         allowNull: false,
         autoIncrement: true,
         primaryKey: true,
-        type: Sequelize.INTEGER
+        type: Sequelize.INTEGER,
       },
       gender: {
-        type: Sequelize.STRING
+        type: Sequelize.STRING,
       },
       age: {
-        type: Sequelize.INTEGER
+        type: Sequelize.INTEGER,
       },
       runNumber: {
-        type: Sequelize.BIGINT
+        type: Sequelize.BIGINT,
       },
       barcodeValue: {
-        type: Sequelize.BIGINT
+        type: Sequelize.BIGINT,
       },
       collectionPointId: {
         allowNull: false,
-        type: Sequelize.INTEGER
+        type: Sequelize.INTEGER,
       },
       status: {
-        type: Sequelize.DataTypes.ENUM('ON_SITE', 'RELEASED', 'TRANSPORTED')
+        type: Sequelize.DataTypes.ENUM('ON_SITE', 'RELEASED', 'TRANSPORTED'),
       },
       triageCategory: {
-        type: Sequelize.INTEGER
+        type: Sequelize.INTEGER,
       },
       triageLevel: {
-        type: Sequelize.DataTypes.ENUM('WHITE', 'GREEN', 'YELLOW', 'RED', 'BLACK')
+        type: Sequelize.DataTypes.ENUM(
+          'WHITE',
+          'GREEN',
+          'YELLOW',
+          'RED',
+          'BLACK'
+        ),
       },
       notes: {
-        type: Sequelize.TEXT
+        type: Sequelize.TEXT,
       },
       transportTime: {
-        type: Sequelize.DATE
+        type: Sequelize.DATE,
       },
       createdAt: {
         allowNull: false,
-        type: Sequelize.DATE
+        type: Sequelize.DATE,
       },
       updatedAt: {
         allowNull: false,
-        type: Sequelize.DATE
-      }
+        type: Sequelize.DATE,
+      },
     });
   },
-  down: (queryInterface, Sequelize) => {
-    return queryInterface.sequelize.transaction(t => {
+  down: (queryInterface) => {
+    return queryInterface.sequelize.transaction((t) => {
       return Promise.all([
-        queryInterface.dropTable('patients'),
-        queryInterface.sequelize.query('DROP TYPE IF EXISTS "enum_patients_triageLevel";'),
-        queryInterface.sequelize.query('DROP TYPE IF EXISTS "enum_patients_status";')
+        queryInterface.dropTable('patients', { transaction: t }),
+        queryInterface.sequelize.query(
+          'DROP TYPE IF EXISTS "enum_patients_triageLevel";',
+          { transaction: t }
+        ),
+        queryInterface.sequelize.query(
+          'DROP TYPE IF EXISTS "enum_patients_status";',
+          { transaction: t }
+        ),
       ]);
     });
-  }
+  },
 };

--- a/migrations/20200213003503-create-hospitals.js
+++ b/migrations/20200213003503-create-hospitals.js
@@ -1,4 +1,5 @@
 'use strict';
+
 module.exports = {
   up: (queryInterface, Sequelize) => {
     return queryInterface.createTable('hospitals', {
@@ -6,23 +7,23 @@ module.exports = {
         allowNull: false,
         autoIncrement: true,
         primaryKey: true,
-        type: Sequelize.INTEGER
+        type: Sequelize.INTEGER,
       },
       name: {
         allowNull: false,
-        type: Sequelize.STRING
+        type: Sequelize.STRING,
       },
       createdAt: {
         allowNull: false,
-        type: Sequelize.DATE
+        type: Sequelize.DATE,
       },
       updatedAt: {
         allowNull: false,
-        type: Sequelize.DATE
-      }
+        type: Sequelize.DATE,
+      },
     });
   },
-  down: (queryInterface, Sequelize) => {
+  down: (queryInterface) => {
     return queryInterface.dropTable('hospitals');
-  }
+  },
 };

--- a/migrations/20200213004252-change-date-column-names.js
+++ b/migrations/20200213004252-change-date-column-names.js
@@ -1,27 +1,56 @@
-"use strict";
+'use strict';
 
 module.exports = {
   up: (queryInterface, Sequelize) => {
-    return queryInterface.sequelize.transaction(t => {
+    return queryInterface.sequelize.transaction((t) => {
       return Promise.all([
-        queryInterface.removeColumn("events", "description"),
-        queryInterface.removeColumn("events", "date"),
-        queryInterface.addColumn("events", "eventDate", {
-          type: Sequelize.DataTypes.DATEONLY,
-          allowNull: false
-        })
+        queryInterface.removeColumn('events', 'description', {
+          transaction: t,
+        }),
+        queryInterface.removeColumn('events', 'date', {
+          transaction: t,
+        }),
+        queryInterface.addColumn(
+          'events',
+          'eventDate',
+          {
+            type: Sequelize.DataTypes.DATEONLY,
+            allowNull: false,
+          },
+          {
+            transaction: t,
+          }
+        ),
       ]);
     });
   },
   down: (queryInterface, Sequelize) => {
-    return Promise.all([
-      queryInterface.addColumn("events", "description", {
-        type: Sequelize.DataTypes.STRING
-      }),
-      queryInterface.addColumn("events", "date", {
-        type: Sequelize.DataTypes.STRING
-      }),
-      queryInterface.removeColumn("events", "eventDate")
-    ]);
-  }
+    return queryInterface.sequelize.transaction((t) => {
+      return Promise.all([
+        queryInterface.addColumn(
+          'events',
+          'description',
+          {
+            type: Sequelize.DataTypes.STRING,
+          },
+          {
+            transaction: t,
+          }
+        ),
+        queryInterface.addColumn(
+          'events',
+          'date',
+          {
+            type: Sequelize.DataTypes.STRING,
+          },
+          {
+            transaction: t,
+          }
+        ),
+        queryInterface.removeColumn('events', 'eventDate', {
+          transaction: t,
+        }),
+      ]);
+    });
+  },
 };

--- a/migrations/20200213013205-create-ambulances.js
+++ b/migrations/20200213013205-create-ambulances.js
@@ -1,4 +1,5 @@
 'use strict';
+
 module.exports = {
   up: (queryInterface, Sequelize) => {
     return queryInterface.createTable('ambulances', {
@@ -6,23 +7,23 @@ module.exports = {
         allowNull: false,
         autoIncrement: true,
         primaryKey: true,
-        type: Sequelize.INTEGER
+        type: Sequelize.INTEGER,
       },
       vehicleNumber: {
         allowNull: false,
-        type: Sequelize.INTEGER
+        type: Sequelize.INTEGER,
       },
       createdAt: {
         allowNull: false,
-        type: Sequelize.DATE
+        type: Sequelize.DATE,
       },
       updatedAt: {
         allowNull: false,
-        type: Sequelize.DATE
-      }
+        type: Sequelize.DATE,
+      },
     });
   },
-  down: (queryInterface, Sequelize) => {
+  down: (queryInterface) => {
     return queryInterface.dropTable('ambulances');
-  }
+  },
 };

--- a/migrations/20200303023602-collectionPoints.js
+++ b/migrations/20200303023602-collectionPoints.js
@@ -2,35 +2,33 @@
 
 module.exports = {
   up: (queryInterface, Sequelize) => {
-
-      return queryInterface.createTable('collectionPoints', {
+    return queryInterface.createTable('collectionPoints', {
       id: {
         allowNull: false,
         autoIncrement: true,
         primaryKey: true,
-        type: Sequelize.INTEGER
+        type: Sequelize.INTEGER,
       },
       name: {
         allowNull: false,
-        type: Sequelize.STRING
+        type: Sequelize.STRING,
       },
       createdAt: {
         allowNull: false,
-        type: Sequelize.DATE
+        type: Sequelize.DATE,
       },
       updatedAt: {
         allowNull: false,
-        type: Sequelize.DATE
+        type: Sequelize.DATE,
       },
       eventId: {
         allowNull: false,
-        type: Sequelize.INTEGER
-      }
+        type: Sequelize.INTEGER,
+      },
     });
-
   },
 
-  down: (queryInterface, Sequelize) => {
+  down: (queryInterface) => {
     return queryInterface.dropTable('collectionPoints');
-  }
+  },
 };

--- a/migrations/20200602002150-add-createdBy-ccp.js
+++ b/migrations/20200602002150-add-createdBy-ccp.js
@@ -1,32 +1,14 @@
-"use strict";
+'use strict';
 
 module.exports = {
   up: (queryInterface, Sequelize) => {
-    return queryInterface.sequelize.transaction(t => {
-      return Promise.all([
-        queryInterface.addColumn(
-          "collectionPoints",
-          "createdBy",
-          {
-            type: Sequelize.DataTypes.INTEGER
-          },
-          { transaction: t }
-        )
-      ]);
+    return queryInterface.addColumn('collectionPoints', 'createdBy', {
+      type: Sequelize.DataTypes.INTEGER,
     });
   },
   down: (queryInterface, Sequelize) => {
-    return queryInterface.sequelize.transaction(t => {
-      return Promise.all([
-        queryInterface.removeColumn(
-          "collectionPoints",
-          "createdBy",
-          {
-            type: Sequelize.DataTypes.INTEGER
-          },
-          { transaction: t }
-        )
-      ]);
+    return queryInterface.removeColumn('collectionPoints', 'createdBy', {
+      type: Sequelize.DataTypes.INTEGER,
     });
-  }
+  },
 };

--- a/migrations/20200609005521-create-eventAmbulances.js
+++ b/migrations/20200609005521-create-eventAmbulances.js
@@ -2,38 +2,37 @@
 
 module.exports = {
   up: (queryInterface, Sequelize) => {
-    return queryInterface.createTable('eventAmbulances', { 
+    return queryInterface.createTable('eventAmbulances', {
       id: {
         allowNull: false,
         autoIncrement: true,
         primaryKey: true,
-        type: Sequelize.INTEGER
+        type: Sequelize.INTEGER,
       },
       eventId: {
         allowNull: false,
         autoIncrement: false,
         primaryKey: false,
-        type: Sequelize.INTEGER
+        type: Sequelize.INTEGER,
       },
       ambulanceId: {
         allowNull: false,
         autoIncrement: false,
         primaryKey: false,
-        type: Sequelize.INTEGER
+        type: Sequelize.INTEGER,
       },
       createdAt: {
         allowNull: false,
-        type: Sequelize.DATE
+        type: Sequelize.DATE,
       },
       updatedAt: {
         allowNull: false,
-        type: Sequelize.DATE
-      }
+        type: Sequelize.DATE,
+      },
     });
-
   },
 
-  down: (queryInterface, Sequelize) => {
+  down: (queryInterface) => {
     return queryInterface.dropTable('eventAmbulances');
-  }
+  },
 };

--- a/migrations/20200609005528-create-eventHospitals.js
+++ b/migrations/20200609005528-create-eventHospitals.js
@@ -2,38 +2,37 @@
 
 module.exports = {
   up: (queryInterface, Sequelize) => {
-    return queryInterface.createTable('eventHospitals', { 
+    return queryInterface.createTable('eventHospitals', {
       id: {
         allowNull: false,
         autoIncrement: true,
         primaryKey: true,
-        type: Sequelize.INTEGER
+        type: Sequelize.INTEGER,
       },
       eventId: {
         allowNull: false,
         autoIncrement: false,
         primaryKey: false,
-        type: Sequelize.INTEGER
+        type: Sequelize.INTEGER,
       },
       hospitalId: {
         allowNull: false,
         autoIncrement: false,
         primaryKey: false,
-        type: Sequelize.INTEGER
+        type: Sequelize.INTEGER,
       },
       createdAt: {
         allowNull: false,
-        type: Sequelize.DATE
+        type: Sequelize.DATE,
       },
       updatedAt: {
         allowNull: false,
-        type: Sequelize.DATE
-      }
+        type: Sequelize.DATE,
+      },
     });
-
   },
 
-  down: (queryInterface, Sequelize) => {
+  down: (queryInterface) => {
     return queryInterface.dropTable('eventHospitals');
-  }
+  },
 };

--- a/migrations/20200705014540-extend-patient-statuses.js
+++ b/migrations/20200705014540-extend-patient-statuses.js
@@ -3,23 +3,23 @@
 const replaceEnum = require('sequelize-replace-enum-postgres').default;
 
 module.exports = {
-  up: (queryInterface, Sequelize) => {
+  up: (queryInterface) => {
     return replaceEnum({
       queryInterface,
       tableName: 'patients',
       columnName: 'status',
       newValues: ['ON_SITE', 'RELEASED', 'TRANSPORTED', 'DELETED'],
-      enumName: 'enum_patients_status'
+      enumName: 'enum_patients_status',
     });
   },
 
-  down: (queryInterface, Sequelize) => {
+  down: (queryInterface) => {
     return replaceEnum({
       queryInterface,
       tableName: 'patients',
       columnName: 'status',
       newValues: ['ON_SITE', 'RELEASED', 'TRANSPORTED'],
-      enumName: 'enum_patients_status'
+      enumName: 'enum_patients_status',
     });
-  }
+  },
 };

--- a/migrations/20200707221810-mandatory-patient-fields.js
+++ b/migrations/20200707221810-mandatory-patient-fields.js
@@ -1,12 +1,12 @@
-"use strict";
+'use strict';
 
 module.exports = {
   up: (queryInterface, Sequelize) => {
     return queryInterface.sequelize.transaction((t) => {
       return Promise.all([
         queryInterface.changeColumn(
-          "patients",
-          "barcodeValue",
+          'patients',
+          'barcodeValue',
           {
             type: Sequelize.BIGINT,
             allowNull: false,
@@ -25,8 +25,8 @@ module.exports = {
     return queryInterface.sequelize.transaction((t) => {
       return Promise.all([
         queryInterface.changeColumn(
-          "patients",
-          "barcodeValue",
+          'patients',
+          'barcodeValue',
           {
             type: Sequelize.BIGINT,
             allowNull: true,

--- a/migrations/20200713233601-add-hospital-column-to-patients.js
+++ b/migrations/20200713233601-add-hospital-column-to-patients.js
@@ -2,10 +2,12 @@
 
 module.exports = {
   up: (queryInterface, Sequelize) => {
-    return queryInterface.addColumn("patients", "hospitalId", { type: Sequelize.DataTypes.INTEGER });
+    return queryInterface.addColumn('patients', 'hospitalId', {
+      type: Sequelize.DataTypes.INTEGER,
+    });
   },
 
-  down: (queryInterface, Sequelize) => {
-    return queryInterface.removeColumn("patients", "hospitalId");
-  }
+  down: (queryInterface) => {
+    return queryInterface.removeColumn('patients', 'hospitalId');
+  },
 };

--- a/migrations/20200715014355-create-location-pins.js
+++ b/migrations/20200715014355-create-location-pins.js
@@ -1,8 +1,8 @@
-"use strict";
+'use strict';
 
 module.exports = {
   up: (queryInterface, Sequelize) => {
-    return queryInterface.createTable("locationPins", {
+    return queryInterface.createTable('locationPins', {
       id: {
         allowNull: false,
         autoIncrement: true,
@@ -38,7 +38,7 @@ module.exports = {
       },
     });
   },
-  down: (queryInterface, Sequelize) => {
-    return queryInterface.dropTable("locationPins");
+  down: (queryInterface) => {
+    return queryInterface.dropTable('locationPins');
   },
 };

--- a/migrations/20200717012421-load-admin-user.js
+++ b/migrations/20200717012421-load-admin-user.js
@@ -1,23 +1,24 @@
 'use strict';
 
 module.exports = {
-  up: (queryInterface, Sequelize) => {
+  up: (queryInterface) => {
     return queryInterface.bulkInsert('users', [
       {
         firstName: 'bp_admin',
         lastName: '',
         email: 'paramedics@uwblueprint.org',
-        accessLevel: "ADMIN",
+        accessLevel: 'ADMIN',
         emergencyContact: '1234567890',
         createdAt: new Date(),
-        updatedAt: new Date()
-      }
+        updatedAt: new Date(),
+      },
     ]);
   },
 
   down: (queryInterface, Sequelize) => {
     const Op = Sequelize.Op;
-    return queryInterface.bulkDelete('users',
-      { email: { [Op.like]: '%paramedics@uwblueprint.org%' } });
-  }
+    return queryInterface.bulkDelete('users', {
+      email: { [Op.like]: '%paramedics@uwblueprint.org%' },
+    });
+  },
 };

--- a/migrations/20200719025533-add-name-column-users.js
+++ b/migrations/20200719025533-add-name-column-users.js
@@ -5,8 +5,8 @@ module.exports = {
     return queryInterface.sequelize.transaction((t) => {
       return Promise.all([
         queryInterface.addColumn(
-          "users",
-          "name",
+          'users',
+          'name',
           {
             type: Sequelize.DataTypes.STRING,
           },
@@ -34,16 +34,16 @@ module.exports = {
     return queryInterface.sequelize.transaction((t) => {
       return Promise.all([
         queryInterface.addColumn(
-          "users",
-          "firstName",
+          'users',
+          'firstName',
           {
             type: Sequelize.DataTypes.STRING,
           },
           { transaction: t }
         ),
         queryInterface.addColumn(
-          "users",
-          "lastName",
+          'users',
+          'lastName',
           {
             type: Sequelize.DataTypes.STRING,
           },
@@ -60,5 +60,5 @@ module.exports = {
         queryInterface.removeColumn('users', 'name', { transaction: t }),
       ]);
     });
-  }
+  },
 };

--- a/migrations/20200719172434-change-patients-barcodeValue-to-string.js
+++ b/migrations/20200719172434-change-patients-barcodeValue-to-string.js
@@ -1,22 +1,23 @@
-"use strict";
+'use strict';
 
 module.exports = {
-     up: (queryInterface, Sequelize) => {
-    return queryInterface.changeColumn(
-      "patients", "barcodeValue", { type: Sequelize.DataTypes.STRING }
-    );
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.changeColumn('patients', 'barcodeValue', {
+      type: Sequelize.DataTypes.STRING,
+    });
   },
   down: (queryInterface, Sequelize) => {
     return queryInterface.sequelize.transaction((t) => {
       return Promise.all([
-        queryInterface.bulkUpdate('patients',
+        queryInterface.bulkUpdate(
+          'patients',
           { barcodeValue: null },
           { barcodeValue: { [Sequelize.Op.regexp]: '[^0-9]' } },
           { transaction: t }
         ),
         queryInterface.changeColumn(
-          "patients",
-          "barcodeValue",
+          'patients',
+          'barcodeValue',
           { type: 'INTEGER USING CAST("barcodeValue" as INTEGER)' },
           {
             transaction: t,

--- a/migrations/20200721211424-add-deletedAt-columns.js
+++ b/migrations/20200721211424-add-deletedAt-columns.js
@@ -1,12 +1,12 @@
-"use strict";
+'use strict';
 
 module.exports = {
   up: (queryInterface, Sequelize) => {
     return queryInterface.sequelize.transaction((t) => {
       return Promise.all([
         queryInterface.addColumn(
-          "users",
-          "deletedAt",
+          'users',
+          'deletedAt',
           {
             allowNull: true,
             type: Sequelize.DataTypes.DATE,
@@ -14,8 +14,8 @@ module.exports = {
           { transaction: t }
         ),
         queryInterface.addColumn(
-          "events",
-          "deletedAt",
+          'events',
+          'deletedAt',
           {
             allowNull: true,
             type: Sequelize.DataTypes.DATE,
@@ -23,8 +23,8 @@ module.exports = {
           { transaction: t }
         ),
         queryInterface.addColumn(
-          "hospitals",
-          "deletedAt",
+          'hospitals',
+          'deletedAt',
           {
             allowNull: true,
             type: Sequelize.DataTypes.DATE,
@@ -32,8 +32,8 @@ module.exports = {
           { transaction: t }
         ),
         queryInterface.addColumn(
-          "ambulances",
-          "deletedAt",
+          'ambulances',
+          'deletedAt',
           {
             allowNull: true,
             type: Sequelize.DataTypes.DATE,
@@ -41,8 +41,8 @@ module.exports = {
           { transaction: t }
         ),
         queryInterface.addColumn(
-          "patients",
-          "deletedAt",
+          'patients',
+          'deletedAt',
           {
             allowNull: true,
             type: Sequelize.DataTypes.DATE,
@@ -50,8 +50,8 @@ module.exports = {
           { transaction: t }
         ),
         queryInterface.addColumn(
-          "collectionPoints",
-          "deletedAt",
+          'collectionPoints',
+          'deletedAt',
           {
             allowNull: true,
             type: Sequelize.DataTypes.DATE,
@@ -59,8 +59,8 @@ module.exports = {
           { transaction: t }
         ),
         queryInterface.addColumn(
-          "eventHospitals",
-          "deletedAt",
+          'eventHospitals',
+          'deletedAt',
           {
             allowNull: true,
             type: Sequelize.DataTypes.DATE,
@@ -68,8 +68,8 @@ module.exports = {
           { transaction: t }
         ),
         queryInterface.addColumn(
-          "eventAmbulances",
-          "deletedAt",
+          'eventAmbulances',
+          'deletedAt',
           {
             allowNull: true,
             type: Sequelize.DataTypes.DATE,
@@ -80,27 +80,27 @@ module.exports = {
     });
   },
 
-  down: (queryInterface, Sequelize) => {
+  down: (queryInterface) => {
     return queryInterface.sequelize.transaction((t) => {
       return Promise.all([
-        queryInterface.removeColumn("users", "deletedAt", { transaction: t }),
-        queryInterface.removeColumn("events", "deletedAt", { transaction: t }),
-        queryInterface.removeColumn("hospitals", "deletedAt", {
+        queryInterface.removeColumn('users', 'deletedAt', { transaction: t }),
+        queryInterface.removeColumn('events', 'deletedAt', { transaction: t }),
+        queryInterface.removeColumn('hospitals', 'deletedAt', {
           transaction: t,
         }),
-        queryInterface.removeColumn("ambulances", "deletedAt", {
+        queryInterface.removeColumn('ambulances', 'deletedAt', {
           transaction: t,
         }),
-        queryInterface.removeColumn("patients", "deletedAt", {
+        queryInterface.removeColumn('patients', 'deletedAt', {
           transaction: t,
         }),
-        queryInterface.removeColumn("collectionPoints", "deletedAt", {
+        queryInterface.removeColumn('collectionPoints', 'deletedAt', {
           transaction: t,
         }),
-        queryInterface.removeColumn("eventHospitals", "deletedAt", {
+        queryInterface.removeColumn('eventHospitals', 'deletedAt', {
           transaction: t,
         }),
-        queryInterface.removeColumn("eventAmbulances", "deletedAt", {
+        queryInterface.removeColumn('eventAmbulances', 'deletedAt', {
           transaction: t,
         }),
       ]);

--- a/migrations/20200730000410-add-ambulance-column-patients.js
+++ b/migrations/20200730000410-add-ambulance-column-patients.js
@@ -2,10 +2,12 @@
 
 module.exports = {
   up: (queryInterface, Sequelize) => {
-    return queryInterface.addColumn("patients", "ambulanceId", { type: Sequelize.DataTypes.INTEGER });
+    return queryInterface.addColumn('patients', 'ambulanceId', {
+      type: Sequelize.DataTypes.INTEGER,
+    });
   },
 
-  down: (queryInterface, Sequelize) => {
-    return queryInterface.removeColumn("patients", "ambulanceId");
-  }
+  down: (queryInterface) => {
+    return queryInterface.removeColumn('patients', 'ambulanceId');
+  },
 };

--- a/migrations/20200812182030-non-paranoid-resource-associations.js
+++ b/migrations/20200812182030-non-paranoid-resource-associations.js
@@ -1,0 +1,41 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface) => {
+    return queryInterface.sequelize.transaction((t) => {
+      return Promise.all([
+        queryInterface.removeColumn('eventHospitals', 'deletedAt', {
+          transaction: t,
+        }),
+        queryInterface.removeColumn('eventAmbulances', 'deletedAt', {
+          transaction: t,
+        }),
+      ]);
+    });
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction((t) => {
+      return Promise.all([
+        queryInterface.addColumn(
+          'eventHospitals',
+          'deletedAt',
+          {
+            allowNull: true,
+            type: Sequelize.DataTypes.DATE,
+          },
+          { transaction: t }
+        ),
+        queryInterface.addColumn(
+          'eventAmbulances',
+          'deletedAt',
+          {
+            allowNull: true,
+            type: Sequelize.DataTypes.DATE,
+          },
+          { transaction: t }
+        ),
+      ]);
+    });
+  },
+};

--- a/models/ambulances.js
+++ b/models/ambulances.js
@@ -1,19 +1,17 @@
-"use strict";
-
-const Event = require("./event");
+'use strict';
 
 module.exports = (sequelize, DataTypes) => {
   const ambulances = sequelize.define(
-    "ambulance",
+    'ambulance',
     {
       vehicleNumber: DataTypes.INTEGER,
     },
     { paranoid: true }
   );
-  ambulances.associate = function (models) {
+  ambulances.associate = (models) => {
     ambulances.belongsToMany(models.event, {
-      through: "eventAmbulances",
-      foreignKey: "ambulanceId",
+      through: 'eventAmbulances',
+      foreignKey: 'ambulanceId',
     });
   };
 

--- a/models/collectionPoint.js
+++ b/models/collectionPoint.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const Event = require('./event');
-const User = require('./user');
-
 module.exports = (sequelize, DataTypes) => {
   const collectionPoint = sequelize.define(
     'collectionPoint',
@@ -32,12 +29,12 @@ module.exports = (sequelize, DataTypes) => {
       hooks: true,
     });
 
-    collectionPoint.belongsTo(User(sequelize, DataTypes), {
+    collectionPoint.belongsTo(models.user, {
       foreignKey: 'createdBy',
       targetKey: 'id',
     });
 
-    collectionPoint.belongsTo(Event(sequelize, DataTypes), {
+    collectionPoint.belongsTo(models.event, {
       foreignKey: 'eventId',
       targetKey: 'id',
     });

--- a/models/collectionPoint.js
+++ b/models/collectionPoint.js
@@ -1,27 +1,25 @@
-"use strict";
+'use strict';
 
-const Event = require("./event");
-const User = require("./user");
+const Event = require('./event');
+const User = require('./user');
 
 module.exports = (sequelize, DataTypes) => {
   const collectionPoint = sequelize.define(
-    "collectionPoint",
+    'collectionPoint',
     {
       name: DataTypes.STRING,
       eventId: DataTypes.INTEGER,
-      //TODO: Add Location (coordinate)
+      // TODO: Add Location (coordinates)
     },
     {
       paranoid: true,
       hooks: {
-        afterDestroy: function (instance, options) {
-          instance.getPatients().then((patients) =>
-            patients.map((patient) => {
-              patient.destroy();
-            })
-          );
+        afterDestroy: (instance) => {
+          instance
+            .getPatients()
+            .then((patients) => patients.map((patient) => patient.destroy()));
         },
-        afterRestore: function (instance, options) {
+        afterRestore: (instance) => {
           instance
             .getPatients({ paranoid: false })
             .then((patients) => patients.map((patient) => patient.restore()));
@@ -29,20 +27,19 @@ module.exports = (sequelize, DataTypes) => {
       },
     }
   );
-  collectionPoint.associate = function (models) {
-    // associations can be defined here
+  collectionPoint.associate = (models) => {
     collectionPoint.hasMany(models.patient, {
       hooks: true,
     });
 
     collectionPoint.belongsTo(User(sequelize, DataTypes), {
-      foreignKey: "createdBy",
-      targetKey: "id",
+      foreignKey: 'createdBy',
+      targetKey: 'id',
     });
 
     collectionPoint.belongsTo(Event(sequelize, DataTypes), {
-      foreignKey: "eventId",
-      targetKey: "id",
+      foreignKey: 'eventId',
+      targetKey: 'id',
     });
   };
   return collectionPoint;

--- a/models/event.js
+++ b/models/event.js
@@ -1,12 +1,10 @@
-"use strict";
+'use strict';
 
-const User = require("./user");
-const Hospital = require("./hospitals");
-const Ambulance = require("./ambulances");
+const User = require('./user');
 
 module.exports = (sequelize, DataTypes) => {
   const Event = sequelize.define(
-    "event",
+    'event',
     {
       name: DataTypes.STRING,
       eventDate: DataTypes.DATEONLY,
@@ -15,14 +13,16 @@ module.exports = (sequelize, DataTypes) => {
     {
       paranoid: true,
       hooks: {
-        afterDestroy: function (instance, options) {
-          instance.getCollectionPoints().then((collectionPoints) =>
-            collectionPoints.map((collectionPoint) => {
-              collectionPoint.destroy();
-            })
-          );
+        afterDestroy: (instance) => {
+          instance
+            .getCollectionPoints()
+            .then((collectionPoints) =>
+              collectionPoints.map((collectionPoint) =>
+                collectionPoint.destroy()
+              )
+            );
         },
-        afterRestore: function (instance, options) {
+        afterRestore: (instance) => {
           instance
             .getCollectionPoints({ paranoid: false })
             .then((collectionPoints) =>
@@ -40,18 +40,18 @@ module.exports = (sequelize, DataTypes) => {
     });
 
     Event.belongsTo(User(sequelize, DataTypes), {
-      foreignKey: "createdBy",
-      targetKey: "id",
+      foreignKey: 'createdBy',
+      targetKey: 'id',
     });
 
     Event.belongsToMany(models.ambulance, {
-      through: "eventAmbulances",
-      foreignKey: "eventId",
+      through: 'eventAmbulances',
+      foreignKey: 'eventId',
     });
 
     Event.belongsToMany(models.hospital, {
-      through: "eventHospitals",
-      foreignKey: "eventId",
+      through: 'eventHospitals',
+      foreignKey: 'eventId',
     });
   };
 

--- a/models/event.js
+++ b/models/event.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const User = require('./user');
-
 module.exports = (sequelize, DataTypes) => {
   const Event = sequelize.define(
     'event',
@@ -39,7 +37,7 @@ module.exports = (sequelize, DataTypes) => {
       hooks: true,
     });
 
-    Event.belongsTo(User(sequelize, DataTypes), {
+    Event.belongsTo(models.user, {
       foreignKey: 'createdBy',
       targetKey: 'id',
     });

--- a/models/eventAmbulances.js
+++ b/models/eventAmbulances.js
@@ -1,15 +1,15 @@
-"use strict";
+'use strict';
 
 module.exports = (sequelize, DataTypes) => {
   const eventAmbulances = sequelize.define(
-    "eventAmbulances",
+    'eventAmbulances',
     {
       eventId: DataTypes.INTEGER,
       ambulanceId: DataTypes.INTEGER,
     },
     { paranoid: true }
   );
-  eventAmbulances.associate = function (models) {
+  eventAmbulances.associate = (models) => {
     eventAmbulances.belongsTo(models.event);
     eventAmbulances.belongsTo(models.ambulance);
   };

--- a/models/eventAmbulances.js
+++ b/models/eventAmbulances.js
@@ -1,14 +1,10 @@
 'use strict';
 
 module.exports = (sequelize, DataTypes) => {
-  const eventAmbulances = sequelize.define(
-    'eventAmbulances',
-    {
-      eventId: DataTypes.INTEGER,
-      ambulanceId: DataTypes.INTEGER,
-    },
-    { paranoid: true }
-  );
+  const eventAmbulances = sequelize.define('eventAmbulances', {
+    eventId: DataTypes.INTEGER,
+    ambulanceId: DataTypes.INTEGER,
+  });
   eventAmbulances.associate = (models) => {
     eventAmbulances.belongsTo(models.event);
     eventAmbulances.belongsTo(models.ambulance);

--- a/models/eventHospitals.js
+++ b/models/eventHospitals.js
@@ -1,14 +1,10 @@
 'use strict';
 
 module.exports = (sequelize, DataTypes) => {
-  const eventHospitals = sequelize.define(
-    'eventHospitals',
-    {
-      eventId: DataTypes.INTEGER,
-      hospitalId: DataTypes.INTEGER,
-    },
-    { paranoid: true }
-  );
+  const eventHospitals = sequelize.define('eventHospitals', {
+    eventId: DataTypes.INTEGER,
+    hospitalId: DataTypes.INTEGER,
+  });
   eventHospitals.associate = (models) => {
     eventHospitals.belongsTo(models.event);
     eventHospitals.belongsTo(models.hospital);

--- a/models/eventHospitals.js
+++ b/models/eventHospitals.js
@@ -1,15 +1,15 @@
-"use strict";
+'use strict';
 
 module.exports = (sequelize, DataTypes) => {
   const eventHospitals = sequelize.define(
-    "eventHospitals",
+    'eventHospitals',
     {
       eventId: DataTypes.INTEGER,
       hospitalId: DataTypes.INTEGER,
     },
     { paranoid: true }
   );
-  eventHospitals.associate = function (models) {
+  eventHospitals.associate = (models) => {
     eventHospitals.belongsTo(models.event);
     eventHospitals.belongsTo(models.hospital);
   };

--- a/models/hospitals.js
+++ b/models/hospitals.js
@@ -1,19 +1,17 @@
-"use strict";
-
-const Event = require("./event");
+'use strict';
 
 module.exports = (sequelize, DataTypes) => {
   const hospitals = sequelize.define(
-    "hospital",
+    'hospital',
     {
       name: DataTypes.STRING,
     },
     { paranoid: true }
   );
-  hospitals.associate = function (models) {
+  hospitals.associate = (models) => {
     hospitals.belongsToMany(models.event, {
-      through: "eventHospitals",
-      foreignKey: "hospitalId",
+      through: 'eventHospitals',
+      foreignKey: 'hospitalId',
     });
   };
 

--- a/models/index.js
+++ b/models/index.js
@@ -1,33 +1,39 @@
 'use strict';
 
-require('dotenv').config()
+require('dotenv').config();
 
 const fs = require('fs');
 const path = require('path');
 const Sequelize = require('sequelize');
 const basename = path.basename(__filename);
 const env = process.env.NODE_ENV || 'development';
-const config = require(__dirname + '/../config/config.js')[env];
+const config = require(path.join(__dirname, '/../config/config.js'))[env];
 const db = {};
 
 let sequelize;
 if (config.use_env_variable) {
   sequelize = new Sequelize(process.env[config.use_env_variable], config);
 } else {
-  sequelize = new Sequelize(config.database, config.username, config.password, config);
+  sequelize = new Sequelize(
+    config.database,
+    config.username,
+    config.password,
+    config
+  );
 }
 
-fs
-  .readdirSync(__dirname)
-  .filter(file => {
-    return (file.indexOf('.') !== 0) && (file !== basename) && (file.slice(-3) === '.js');
+fs.readdirSync(__dirname)
+  .filter((file) => {
+    return (
+      file.indexOf('.') !== 0 && file !== basename && file.slice(-3) === '.js'
+    );
   })
-  .forEach(file => {
-    const model = sequelize['import'](path.join(__dirname, file));
+  .forEach((file) => {
+    const model = sequelize.import(path.join(__dirname, file));
     db[model.name] = model;
   });
 
-Object.keys(db).forEach(modelName => {
+Object.keys(db).forEach((modelName) => {
   if (db[modelName].associate) {
     db[modelName].associate(db);
   }

--- a/models/locationPins.js
+++ b/models/locationPins.js
@@ -1,10 +1,10 @@
-"use strict";
+'use strict';
 
-const Event = require("./event");
+const Event = require('./event');
 
 module.exports = (sequelize, DataTypes) => {
   const locationPin = sequelize.define(
-    "locationPins",
+    'locationPins',
     {
       label: DataTypes.STRING,
       eventId: DataTypes.INTEGER,
@@ -14,12 +14,12 @@ module.exports = (sequelize, DataTypes) => {
     },
     { paranoid: true }
   );
-  locationPin.associate = function (models) {
+  locationPin.associate = (models) => {
     // associations can be defined here
 
     locationPin.belongsTo(Event(sequelize, DataTypes), {
-      foreignKey: "eventId",
-      targetKey: "id",
+      foreignKey: 'eventId',
+      targetKey: 'id',
     });
   };
   return locationPin;

--- a/models/locationPins.js
+++ b/models/locationPins.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const Event = require('./event');
-
 module.exports = (sequelize, DataTypes) => {
   const locationPin = sequelize.define(
     'locationPins',
@@ -17,7 +15,7 @@ module.exports = (sequelize, DataTypes) => {
   locationPin.associate = (models) => {
     // associations can be defined here
 
-    locationPin.belongsTo(Event(sequelize, DataTypes), {
+    locationPin.belongsTo(models.event, {
       foreignKey: 'eventId',
       targetKey: 'id',
     });

--- a/models/patient.js
+++ b/models/patient.js
@@ -1,12 +1,12 @@
-"use strict";
+'use strict';
 
-const collectionPoint = require("./collectionPoint");
-const hospitals = require("./hospitals");
-const ambulances = require("./ambulances");
+const collectionPoint = require('./collectionPoint');
+const hospitals = require('./hospitals');
+const ambulances = require('./ambulances');
 
 module.exports = (sequelize, DataTypes) => {
   const Patient = sequelize.define(
-    "patient",
+    'patient',
     {
       gender: DataTypes.STRING,
       age: DataTypes.INTEGER,
@@ -14,12 +14,12 @@ module.exports = (sequelize, DataTypes) => {
       barcodeValue: DataTypes.STRING,
       status: {
         type: DataTypes.ENUM,
-        values: ["ON_SITE", "RELEASED", "TRANSPORTED"],
+        values: ['ON_SITE', 'RELEASED', 'TRANSPORTED', 'DELETED'],
       },
       triageCategory: DataTypes.INTEGER,
       triageLevel: {
         type: DataTypes.ENUM,
-        values: ["WHITE", "GREEN", "YELLOW", "RED", "BLACK"],
+        values: ['WHITE', 'GREEN', 'YELLOW', 'RED', 'BLACK'],
       },
       notes: DataTypes.TEXT,
       transportTime: DataTypes.DATE,
@@ -29,17 +29,17 @@ module.exports = (sequelize, DataTypes) => {
     { paranoid: true }
   );
   Patient.associate = (models) => {
-    Patient.belongsTo(collectionPoint(sequelize, DataTypes), {
-      foreignKey: "collectionPointId",
-      targetKey: "id",
+    Patient.belongsTo(models.collectionPoint, {
+      foreignKey: 'collectionPointId',
+      targetKey: 'id',
     });
     Patient.belongsTo(hospitals(sequelize, DataTypes), {
-      foreignKey: "hospitalId",
-      targetKey: "id",
+      foreignKey: 'hospitalId',
+      targetKey: 'id',
     });
     Patient.belongsTo(ambulances(sequelize, DataTypes), {
-      foreignKey: "ambulanceId",
-      targetKey: "id",
+      foreignKey: 'ambulanceId',
+      targetKey: 'id',
     });
   };
   return Patient;

--- a/models/patient.js
+++ b/models/patient.js
@@ -1,9 +1,5 @@
 'use strict';
 
-const collectionPoint = require('./collectionPoint');
-const hospitals = require('./hospitals');
-const ambulances = require('./ambulances');
-
 module.exports = (sequelize, DataTypes) => {
   const Patient = sequelize.define(
     'patient',
@@ -33,11 +29,11 @@ module.exports = (sequelize, DataTypes) => {
       foreignKey: 'collectionPointId',
       targetKey: 'id',
     });
-    Patient.belongsTo(hospitals(sequelize, DataTypes), {
+    Patient.belongsTo(models.hospital, {
       foreignKey: 'hospitalId',
       targetKey: 'id',
     });
-    Patient.belongsTo(ambulances(sequelize, DataTypes), {
+    Patient.belongsTo(models.ambulance, {
       foreignKey: 'ambulanceId',
       targetKey: 'id',
     });

--- a/models/user.js
+++ b/models/user.js
@@ -1,11 +1,12 @@
-"use strict";
+'use strict';
+
 module.exports = (sequelize, DataTypes) => {
   const User = sequelize.define(
-    "user",
+    'user',
     {
       accessLevel: {
         type: DataTypes.ENUM,
-        values: ["COMMANDER", "SUPERVISOR", "ADMIN"],
+        values: ['COMMANDER', 'SUPERVISOR', 'ADMIN'],
       },
       name: DataTypes.STRING,
       email: DataTypes.STRING,
@@ -14,8 +15,5 @@ module.exports = (sequelize, DataTypes) => {
     },
     {}
   );
-  User.associate = function (models) {
-    // associations can be defined here
-  };
   return User;
 };

--- a/resolvers/ambulance.js
+++ b/resolvers/ambulance.js
@@ -1,7 +1,6 @@
-"use strict";
+'use strict';
 
-const db = require("../models");
-const { Op } = require("sequelize");
+const db = require('../models');
 
 const ambulanceResolvers = {
   Query: {
@@ -13,7 +12,7 @@ const ambulanceResolvers = {
           },
         ],
       }),
-    ambulance: (obj, args, context, info) =>
+    ambulance: (obj, args) =>
       db.ambulance.findByPk(args.id, {
         include: [
           {
@@ -43,7 +42,7 @@ const ambulanceResolvers = {
         )
         .then((rowsAffected) => {
           if (rowsAffected[0] === 0) {
-            throw new Error("Update for ambulance table failed");
+            throw new Error('Update for ambulance table failed');
           }
         });
 
@@ -93,7 +92,7 @@ const ambulanceResolvers = {
         .then((count) => {
           if (count > 0) {
             throw new Error(
-              "Deletion failed; there are associated patients for this ambulance"
+              'Deletion failed; there are associated patients for this ambulance'
             );
           }
         });

--- a/resolvers/collectionPoint.js
+++ b/resolvers/collectionPoint.js
@@ -1,35 +1,34 @@
-"use strict";
+'use strict';
 
-const db = require("../models");
+const db = require('../models');
 
 const collectionPointResolvers = {
   Query: {
     collectionPoints: () => db.collectionPoint.findAll(),
-    collectionPoint: (obj, args, context, info) =>
-      db.collectionPoint.findByPk(args.id),
-    collectionPointsByEvent: (obj, args, context, info) =>
+    collectionPoint: (obj, args) => db.collectionPoint.findByPk(args.id),
+    collectionPointsByEvent: (obj, args) =>
       db.collectionPoint.findAll({ where: { eventId: args.eventId } }),
   },
 
   collectionPoint: {
-    eventId: (obj, args, context, info) => db.event.findByPk(obj.eventId),
-    createdBy: (obj, args, context, info) => db.user.findByPk(obj.createdBy),
+    eventId: (obj) => db.event.findByPk(obj.eventId),
+    createdBy: (obj) => db.user.findByPk(obj.createdBy),
   },
 
   // CRUD Operations
   Mutation: {
     addCollectionPoint: async (parent, args) => {
-      //Checks if eventId is valid
+      // Checks if eventId is valid
       const event = await db.event.findByPk(args.eventId);
 
       // Check if createdBy is valid
       const user = await db.user.findByPk(args.createdBy);
       if (!user) {
-        throw new Error("Invalid user ID");
+        throw new Error('Invalid user ID');
       }
 
       if (!event) {
-        throw new Error("Invalid event ID");
+        throw new Error('Invalid event ID');
       }
       return db.collectionPoint.create({
         name: args.name,
@@ -38,11 +37,11 @@ const collectionPointResolvers = {
       });
     },
     updateCollectionPoint: async (parent, args) => {
-      //Checks if eventId is valid
+      // Checks if eventId is valid
       if (args.eventId) {
         const event = await db.event.findByPk(args.eventId);
         if (!event) {
-          throw new Error("Invalid event ID");
+          throw new Error('Invalid event ID');
         }
       }
 
@@ -50,7 +49,7 @@ const collectionPointResolvers = {
       if (args.createdBy) {
         const user = await db.user.findByPk(args.createdBy);
         if (!user) {
-          throw new Error("Invalid user ID");
+          throw new Error('Invalid user ID');
         }
       }
 
@@ -68,8 +67,8 @@ const collectionPointResolvers = {
           }
         )
         .then((rowsAffected) => {
-          if (rowsAffected[0] == 0) {
-            throw new Error("this Collection Point does not exist");
+          if (rowsAffected[0] === 0) {
+            throw new Error('This Collection Point does not exist');
           }
         });
       return db.collectionPoint.findByPk(args.id);

--- a/resolvers/event.js
+++ b/resolvers/event.js
@@ -1,6 +1,6 @@
-"use strict";
+'use strict';
 
-const db = require("../models");
+const db = require('../models');
 
 const eventResolvers = {
   Query: {
@@ -15,7 +15,7 @@ const eventResolvers = {
           },
         ],
       }),
-    event: (obj, args, context, info) =>
+    event: (obj, args) =>
       db.event.findByPk(args.id, {
         include: [
           {
@@ -34,15 +34,16 @@ const eventResolvers = {
       }),
   },
   Event: {
-    createdBy: (obj, args, context, info) => db.user.findByPk(obj.createdBy),
+    createdBy: (obj) => db.user.findByPk(obj.createdBy),
   },
   Mutation: {
     addEvent: async (parent, args) => {
       // Check if createdBy is valid
-      const user = await db.user.findByPk(args.createdBy);
-      if (!user) {
-        throw new Error("Invalid user ID");
-      }
+      await db.user.findByPk(args.createdBy).then((user) => {
+        if (!user) {
+          throw new Error('Invalid user ID: ' + args.createdBy);
+        }
+      });
 
       await db.event.create({
         name: args.name,
@@ -62,27 +63,33 @@ const eventResolvers = {
     },
     updateEvent: async (parent, args) => {
       // Checking if event is valid
-      const event = await db.event.findByPk(args.id);
-      if (!event) {
-        throw new Error("Invalid event ID");
-      }
+      await db.event.findByPk(args.id).then((event) => {
+        if (!event) {
+          throw new Error('Invalid event ID: ' + args.id);
+        }
+      });
 
       // Checking if user is valid
       if (args.createdBy) {
-        const user = await db.user.findByPk(args.createdBy);
-        if (!user) {
-          throw new Error("Invalid user ID");
-        }
+        await db.user.findByPk(args.createdBy).then((user) => {
+          if (!user) {
+            throw new Error('Invalid user ID: ' + args.createdBy);
+          }
+        });
       }
 
-      const addAmbulances = async () => {
-        // Checking if ambulances are valid
-        for (const ambulanceId of args.ambulances) {
-          const ambulance = await db.ambulance.findByPk(ambulanceId["id"]);
-          if (!ambulance) {
-            return true;
-          }
-        }
+      if (args.ambulances) {
+        // Checking if all ambulances exist
+        await Promise.all(
+          args.ambulances.map((ambulanceId) =>
+            db.ambulance.findByPk(ambulanceId.id).then((ambulance) => {
+              if (!ambulance) {
+                throw new Error('Invalid ambulance ID: ' + ambulanceId.id);
+              }
+            })
+          )
+        );
+
         // Removing all instances of this particular event in the junction table
         await db.eventAmbulances.destroy({
           where: {
@@ -91,57 +98,44 @@ const eventResolvers = {
         });
 
         // Adding in all relations of the given event and the given ambulances
-        for (const ambulanceId of args.ambulances) {
-          await db.eventAmbulances.create({
-            eventId: args.id,
-            ambulanceId: ambulanceId["id"],
-          });
-        }
-
-        return false;
-      };
-
-      // Calling async function to actually conduct association operations
-      if (args.ambulances) {
-        const ambulanceHasError = await addAmbulances();
-        if (ambulanceHasError) {
-          throw new Error("Invalid ambulance ID");
-        }
+        await Promise.all(
+          args.ambulances.map((ambulanceId) =>
+            db.eventAmbulances.create({
+              eventId: args.id,
+              ambulanceId: ambulanceId.id,
+            })
+          )
+        );
       }
 
-      const addHospitals = async () => {
-        // Checking if hospitals are valid
-        for (const hospitalId of args.hospitals) {
-          const hospital = await db.hospital.findByPk(hospitalId["id"]);
-          if (!hospital) {
-            return true;
-          }
-        }
+      if (args.hospitals) {
+        // Checking if all hospitals exist
+        await Promise.all(
+          args.hospitals.map((hospitalId) =>
+            db.hospital.findByPk(hospitalId.id).then((hospital) => {
+              if (!hospital) {
+                throw new Error('Invalid hospital ID: ' + hospitalId.id);
+              }
+            })
+          )
+        );
 
-        // Removing all records of event in eventHospital junction table
+        // Removing all instances of this particular event in the junction table
         await db.eventHospitals.destroy({
           where: {
             eventId: args.id,
           },
         });
 
-        // Adding in records of a singular association with the event and the hospital
-        for (const hospitalId of args.hospitals) {
-          await db.eventHospitals.create({
-            eventId: args.id,
-            hospitalId: hospitalId["id"],
-          });
-        }
-
-        return false;
-      };
-
-      if (args.hospitals) {
-        // Checking if hospitals are valid
-        const hospitalHasError = await addHospitals();
-        if (hospitalHasError) {
-          throw new Error("Invalid hospital ID");
-        }
+        // Adding in all relations of the given event and the given hospitals
+        await Promise.all(
+          args.hospitals.map((hospitalId) =>
+            db.eventHospitals.create({
+              eventId: args.id,
+              hospitalId: hospitalId.id,
+            })
+          )
+        );
       }
 
       await db.event.update(
@@ -159,54 +153,76 @@ const eventResolvers = {
         include: [
           {
             model: db.ambulance,
-            attributes: ["id", "vehicleNumber", "createdAt", "updatedAt"],
+            attributes: ['id', 'vehicleNumber', 'createdAt', 'updatedAt'],
           },
           {
             model: db.hospital,
-            attributes: ["id", "name", "createdAt", "updatedAt"],
+            attributes: ['id', 'name', 'createdAt', 'updatedAt'],
           },
         ],
       });
     },
     addAmbulancesToEvent: async (parent, args) => {
       // Checking if event exists
-      const event = await db.event.findByPk(args.eventId);
-      if (!event) {
-        throw new Error("Invalid event ID");
-      }
+      await db.event.findByPk(args.eventId).then(async (event) => {
+        if (!event) {
+          throw new Error('Invalid event ID: ' + args.eventId);
+        }
+      });
 
       // Checking if all ambulances exist
-      for (const ambulanceId of args.ambulances) {
-        const ambulance = await db.ambulance.findByPk(ambulanceId["id"]);
-        if (!ambulance) {
-          throw new Error("Invalid ambulance ID");
-        }
-      }
+      await Promise.all(
+        args.ambulances.map((ambulanceId) =>
+          db.ambulance.findByPk(ambulanceId.id).then((ambulance) => {
+            if (!ambulance) {
+              throw new Error('Invalid ambulance ID: ' + ambulanceId.id);
+            }
+          })
+        )
+      );
 
-      for (const ambulanceId of args.ambulances) {
-        // Checking if association between ambulance and event already exists
-        const eventAmbulanceAssociations = await db.eventAmbulances.findAll({
-          where: {
-            eventId: args.eventId,
-            ambulanceId: ambulanceId["id"],
-          },
-          paranoid: false,
-        });
-
-        if (eventAmbulanceAssociations.length === 0) {
-          await db.eventAmbulances.create({
-            eventId: args.eventId,
-            ambulanceId: ambulanceId["id"],
-          });
-        } else {
-          await db.eventAmbulances.restore({
-            where: {
-              eventId: args.eventId,
-              ambulanceId: ambulanceId["id"],
-            },
-          });
-        }
-      }
+      await Promise.all(
+        args.ambulances.map((ambulanceId) =>
+          db.eventAmbulances
+            .findAll({
+              where: {
+                eventId: args.eventId,
+                ambulanceId: ambulanceId.id,
+              },
+              paranoid: false,
+            })
+            .then((eventAmbulanceAssociations) => {
+              if (eventAmbulanceAssociations.length === 0) {
+                db.eventAmbulances.create({
+                  eventId: args.eventId,
+                  ambulanceId: ambulanceId.id,
+                });
+              } else if (eventAmbulanceAssociations.length > 1) {
+                db.eventAmbulances
+                  .destroy({
+                    where: {
+                      eventId: args.eventId,
+                      ambulanceId: ambulanceId.id,
+                    },
+                    force: true,
+                  })
+                  .then(() =>
+                    db.eventAmbulances.create({
+                      eventId: args.eventId,
+                      ambulanceId: ambulanceId.id,
+                    })
+                  );
+              } else {
+                db.eventAmbulances.restore({
+                  where: {
+                    eventId: args.eventId,
+                    ambulanceId: ambulanceId.id,
+                  },
+                });
+              }
+            })
+        )
+      );
 
       // Returning new event
       return db.event.findByPk(args.eventId, {
@@ -220,47 +236,70 @@ const eventResolvers = {
         ],
       });
     },
+
     addHospitalsToEvent: async (parent, args) => {
       // Checking if event exists
-      const event = await db.event.findByPk(args.eventId);
-      if (!event) {
-        throw new Error("Invalid event ID");
-      }
+      await db.event.findByPk(args.eventId).then(async (event) => {
+        if (!event) {
+          throw new Error('Invalid event ID: ' + args.eventId);
+        }
+      });
 
       // Checking if all hospitals exist
-      for (const hospitalId of args.hospitals) {
-        const hospital = await db.hospital.findByPk(hospitalId["id"]);
-        if (!hospital) {
-          throw new Error("Invalid hospital ID");
-        }
-      }
+      await Promise.all(
+        args.hospitals.map((hospitalId) =>
+          db.hospital.findByPk(hospitalId.id).then((hospital) => {
+            if (!hospital) {
+              throw new Error('Invalid hospital ID: ' + hospitalId.id);
+            }
+          })
+        )
+      );
 
-      for (const hospitalId of args.hospitals) {
-        // Checking if association between ambulance and event already exists
-        const eventHospitalAssociations = await db.eventHospitals.findAll({
-          where: {
-            eventId: args.eventId,
-            hospitalId: hospitalId["id"],
-          },
-          paranoid: false,
-        });
+      await Promise.all(
+        args.hospitals.map((hospitalId) =>
+          db.eventHospitals
+            .findAll({
+              where: {
+                eventId: args.eventId,
+                hospitalId: hospitalId.id,
+              },
+              paranoid: false,
+            })
+            .then((eventHospitalAssociations) => {
+              if (eventHospitalAssociations.length === 0) {
+                db.eventHospitals.create({
+                  eventId: args.eventId,
+                  hospitalId: hospitalId.id,
+                });
+              } else if (eventHospitalAssociations.length > 1) {
+                db.eventHospitals
+                  .destroy({
+                    where: {
+                      eventId: args.eventId,
+                      hospitalId: hospitalId.id,
+                    },
+                    force: true,
+                  })
+                  .then(() =>
+                    db.eventHospitals.create({
+                      eventId: args.eventId,
+                      hospitalId: hospitalId.id,
+                    })
+                  );
+              } else {
+                db.eventHospitals.restore({
+                  where: {
+                    eventId: args.eventId,
+                    hospitalId: hospitalId.id,
+                  },
+                });
+              }
+            })
+        )
+      );
 
-        if (eventHospitalAssociations.length === 0) {
-          await db.eventHospitals.create({
-            eventId: args.eventId,
-            hospitalId: hospitalId["id"],
-          });
-        } else {
-          await db.eventHospitals.restore({
-            where: {
-              eventId: args.eventId,
-              hospitalId: hospitalId["id"],
-            },
-          });
-        }
-      }
-
-      // Returning new event
+      // Returning updated event
       return db.event.findByPk(args.eventId, {
         include: [
           {
@@ -272,32 +311,39 @@ const eventResolvers = {
         ],
       });
     },
+
     deleteAmbulancesFromEvent: async (parent, args) => {
       // Checking if event exists
-      const event = await db.event.findByPk(args.eventId);
-      if (!event) {
-        throw new Error("Invalid event ID");
-      }
+      await db.event.findByPk(args.eventId).then(async (event) => {
+        if (!event) {
+          throw new Error('Invalid event ID: ' + args.eventId);
+        }
+      });
 
       // Checking if all ambulances exist
-      for (const ambulanceId of args.ambulances) {
-        const ambulance = await db.ambulance.findByPk(ambulanceId["id"]);
-        if (!ambulance) {
-          throw new Error("Invalid ambulance ID");
-        }
-      }
+      await Promise.all(
+        args.ambulances.map((ambulanceId) =>
+          db.ambulance.findByPk(ambulanceId.id).then((ambulance) => {
+            if (!ambulance) {
+              throw new Error('Invalid ambulance ID: ' + ambulanceId.id);
+            }
+          })
+        )
+      );
 
-      for (const ambulanceId of args.ambulances) {
-        // Removing association in eventAmbulances junction table
-        await db.eventAmbulances.destroy({
-          where: {
-            eventId: args.eventId,
-            ambulanceId: ambulanceId["id"],
-          },
-        });
-      }
+      // Removing association in eventAmbulance junction table
+      await Promise.all(
+        args.ambulances.map((ambulanceId) =>
+          db.eventAmbulances.destroy({
+            where: {
+              eventId: args.eventId,
+              ambulanceId: ambulanceId.id,
+            },
+          })
+        )
+      );
 
-      // Returning new event
+      // Returning updated event
       return db.event.findByPk(args.eventId, {
         include: [
           {
@@ -309,32 +355,39 @@ const eventResolvers = {
         ],
       });
     },
+
     deleteHospitalsFromEvent: async (parent, args) => {
       // Checking if event exists
-      const event = await db.event.findByPk(args.eventId);
-      if (!event) {
-        throw new Error("Invalid event ID");
-      }
+      await db.event.findByPk(args.eventId).then(async (event) => {
+        if (!event) {
+          throw new Error('Invalid event ID: ' + args.eventId);
+        }
+      });
 
       // Checking if all hospitals exist
-      for (const hospitalId of args.hospitals) {
-        const hospital = await db.hospital.findByPk(hospitalId["id"]);
-        if (!hospital) {
-          throw new Error("Invalid hospital ID");
-        }
-      }
+      await Promise.all(
+        args.hospitals.map((hospitalId) =>
+          db.hospital.findByPk(hospitalId.id).then((hospital) => {
+            if (!hospital) {
+              throw new Error('Invalid hospital ID: ' + hospitalId.id);
+            }
+          })
+        )
+      );
 
-      for (const hospitalId of args.hospitals) {
-        // Removing association in eventHospitals junction table
-        await db.eventHospitals.destroy({
-          where: {
-            eventId: args.eventId,
-            hospitalId: hospitalId["id"],
-          },
-        });
-      }
+      // Removing association in eventHospitals junction table
+      await Promise.all(
+        args.hospitals.map((hospitalId) =>
+          db.eventHospitals.destroy({
+            where: {
+              eventId: args.eventId,
+              hospitalId: hospitalId.id,
+            },
+          })
+        )
+      );
 
-      // Returning new event
+      // Returning updated event
       return db.event.findByPk(args.eventId, {
         include: [
           {
@@ -346,6 +399,7 @@ const eventResolvers = {
         ],
       });
     },
+
     deleteEvent: async (parent, args) => {
       // Return status for destroy
       // 1 for successful deletion, 0 otherwise

--- a/resolvers/event.js
+++ b/resolvers/event.js
@@ -182,42 +182,19 @@ const eventResolvers = {
       );
 
       await Promise.all(
-        args.ambulances.map((ambulanceId) =>
+        args.ambulances.map(async (ambulanceId) =>
           db.eventAmbulances
             .findAll({
               where: {
                 eventId: args.eventId,
                 ambulanceId: ambulanceId.id,
               },
-              paranoid: false,
             })
-            .then((eventAmbulanceAssociations) => {
+            .then(async (eventAmbulanceAssociations) => {
               if (eventAmbulanceAssociations.length === 0) {
-                db.eventAmbulances.create({
+                await db.eventAmbulances.create({
                   eventId: args.eventId,
                   ambulanceId: ambulanceId.id,
-                });
-              } else if (eventAmbulanceAssociations.length > 1) {
-                db.eventAmbulances
-                  .destroy({
-                    where: {
-                      eventId: args.eventId,
-                      ambulanceId: ambulanceId.id,
-                    },
-                    force: true,
-                  })
-                  .then(() =>
-                    db.eventAmbulances.create({
-                      eventId: args.eventId,
-                      ambulanceId: ambulanceId.id,
-                    })
-                  );
-              } else {
-                db.eventAmbulances.restore({
-                  where: {
-                    eventId: args.eventId,
-                    ambulanceId: ambulanceId.id,
-                  },
                 });
               }
             })
@@ -257,42 +234,19 @@ const eventResolvers = {
       );
 
       await Promise.all(
-        args.hospitals.map((hospitalId) =>
+        args.hospitals.map(async (hospitalId) =>
           db.eventHospitals
             .findAll({
               where: {
                 eventId: args.eventId,
                 hospitalId: hospitalId.id,
               },
-              paranoid: false,
             })
-            .then((eventHospitalAssociations) => {
+            .then(async (eventHospitalAssociations) => {
               if (eventHospitalAssociations.length === 0) {
-                db.eventHospitals.create({
+                await db.eventHospitals.create({
                   eventId: args.eventId,
                   hospitalId: hospitalId.id,
-                });
-              } else if (eventHospitalAssociations.length > 1) {
-                db.eventHospitals
-                  .destroy({
-                    where: {
-                      eventId: args.eventId,
-                      hospitalId: hospitalId.id,
-                    },
-                    force: true,
-                  })
-                  .then(() =>
-                    db.eventHospitals.create({
-                      eventId: args.eventId,
-                      hospitalId: hospitalId.id,
-                    })
-                  );
-              } else {
-                db.eventHospitals.restore({
-                  where: {
-                    eventId: args.eventId,
-                    hospitalId: hospitalId.id,
-                  },
                 });
               }
             })

--- a/resolvers/hospital.js
+++ b/resolvers/hospital.js
@@ -1,6 +1,6 @@
-"use strict";
+'use strict';
 
-const db = require("../models");
+const db = require('../models');
 
 const hospitalResolvers = {
   Query: {
@@ -12,7 +12,7 @@ const hospitalResolvers = {
           },
         ],
       }),
-    hospital(obj, args, context, info) {
+    hospital(obj, args) {
       return db.hospital.findByPk(args.id, {
         include: [
           {
@@ -42,7 +42,7 @@ const hospitalResolvers = {
         )
         .then((rowsAffected) => {
           if (rowsAffected[0] === 0) {
-            throw new Error("Update failed for hospital table");
+            throw new Error('Update failed for hospital table');
           }
         });
       return db.hospital.findByPk(args.id);
@@ -89,7 +89,7 @@ const hospitalResolvers = {
         .then((count) => {
           if (count > 0) {
             throw new Error(
-              "Deletion failed; there are associated patients for this hospital"
+              'Deletion failed; there are associated patients for this hospital'
             );
           }
         });

--- a/resolvers/locationPin.js
+++ b/resolvers/locationPin.js
@@ -1,12 +1,12 @@
-"use strict";
+'use strict';
 
-const db = require("../models");
+const db = require('../models');
 
 const locationPinResolvers = {
   Query: {
     pins: () => db.locationPins.findAll(),
-    pin: (obj, args, context, info) => db.locationPins.findByPk(args.id),
-    pinsForEvent: (obj, args, context, info) =>
+    pin: (obj, args) => db.locationPins.findByPk(args.id),
+    pinsForEvent: (obj, args) =>
       db.locationPins.findAll({
         where: {
           eventId: args.eventId,
@@ -15,17 +15,17 @@ const locationPinResolvers = {
   },
 
   LocationPin: {
-    eventId: (obj, args, context, info) => db.event.findByPk(obj.eventId),
+    eventId: (obj) => db.event.findByPk(obj.eventId),
   },
 
   // CRUD Operations
   Mutation: {
     addLocationPin: async (parent, args) => {
-      //Checks if eventId is valid
+      // Checks if eventId is valid
       const event = await db.event.findByPk(args.eventId);
 
       if (!event) {
-        throw new Error("Invalid event ID");
+        throw new Error('Invalid event ID');
       }
       return db.locationPins.create({
         label: args.label,
@@ -36,11 +36,11 @@ const locationPinResolvers = {
       });
     },
     updateLocationPin: async (parent, args) => {
-      //Checks if eventId is valid
+      // Checks if eventId is valid
       if (args.eventId) {
         const event = await db.event.findByPk(args.eventId);
         if (!event) {
-          throw new Error("Invalid event ID");
+          throw new Error('Invalid event ID');
         }
       }
 
@@ -60,8 +60,8 @@ const locationPinResolvers = {
           }
         )
         .then((rowsAffected) => {
-          if (rowsAffected[0] == 0) {
-            throw new Error("This location pin does not exist");
+          if (rowsAffected[0] === 0) {
+            throw new Error('This location pin does not exist');
           }
         });
       return db.locationPins.findByPk(args.id);

--- a/resolvers/patient.js
+++ b/resolvers/patient.js
@@ -1,25 +1,23 @@
-"use strict";
+'use strict';
 
-const db = require("../models");
+const db = require('../models');
 
 const patientResolvers = {
   Query: {
     patients: () => db.patient.findAll(),
-    patient(obj, args, context, info) {
+    patient(obj, args) {
       return db.patient.findByPk(args.id);
     },
-    patientsByCcp: (obj, args, context, info) =>
+    patientsByCcp: (obj, args) =>
       db.patient.findAll({
         where: { collectionPointId: args.collectionPointId },
       }),
   },
   Patient: {
-    collectionPointId: (obj, args, context, info) =>
+    collectionPointId: (obj) =>
       db.collectionPoint.findByPk(obj.collectionPointId),
-    hospitalId: (obj, args, context, info) =>
-      db.hospital.findByPk(obj.hospitalId),
-    ambulanceId: (obj, args, context, info) =>
-      db.ambulance.findByPk(obj.ambulanceId),
+    hospitalId: (obj) => db.hospital.findByPk(obj.hospitalId),
+    ambulanceId: (obj) => db.ambulance.findByPk(obj.ambulanceId),
   },
   Mutation: {
     addPatient: async (parent, args) => {
@@ -27,18 +25,18 @@ const patientResolvers = {
         args.collectionPointId
       );
       if (!collectionPoint) {
-        throw new Error("Invalid collection point ID");
+        throw new Error('Invalid collection point ID');
       }
       if (args.hospitalId) {
         const hospital = await db.hospital.findByPk(args.hospitalId);
         if (!hospital) {
-          throw new Error("Invalid hospital ID");
+          throw new Error('Invalid hospital ID');
         }
       }
       if (args.ambulanceId) {
         const ambulance = await db.ambulance.findByPk(args.ambulanceId);
         if (!ambulance) {
-          throw new Error("Invalid ambulance ID");
+          throw new Error('Invalid ambulance ID');
         }
       }
       return db.patient.create({
@@ -59,26 +57,26 @@ const patientResolvers = {
     updatePatient: async (parent, args) => {
       const patient = await db.patient.findByPk(args.id);
       if (!patient) {
-        throw new Error("Invalid patient ID");
+        throw new Error('Invalid patient ID');
       }
       if (args.collectionPointId) {
         const collectionPoint = await db.collectionPoint.findByPk(
           args.collectionPointId
         );
         if (!collectionPoint) {
-          throw new Error("Invalid collection point ID");
+          throw new Error('Invalid collection point ID');
         }
       }
       if (args.hospitalId) {
         const hospital = await db.hospital.findByPk(args.hospitalId);
         if (!hospital) {
-          throw new Error("Invalid hospital ID");
+          throw new Error('Invalid hospital ID');
         }
       }
       if (args.ambulanceId) {
         const ambulance = await db.ambulance.findByPk(args.ambulanceId);
         if (!ambulance) {
-          throw new Error("Invalid ambulance ID");
+          throw new Error('Invalid ambulance ID');
         }
       }
       await db.patient.update(
@@ -115,7 +113,7 @@ const patientResolvers = {
     deletePatient: async (parent, args) => {
       const isDeleted = await db.patient.update(
         {
-          status: "DELETED",
+          status: 'DELETED',
         },
         {
           where: { id: args.id },

--- a/resolvers/user.js
+++ b/resolvers/user.js
@@ -1,11 +1,11 @@
-"use strict";
+'use strict';
 
-const db = require("../models");
+const db = require('../models');
 
 const userResolvers = {
   Query: {
     users: () => db.user.findAll(),
-    user(obj, args, context, info) {
+    user(obj, args) {
       return db.user.findByPk(args.id);
     },
   },
@@ -36,7 +36,7 @@ const userResolvers = {
         )
         .then((rowsAffected) => {
           if (rowsAffected[0] === 0) {
-            throw new Error("Update failed for user table");
+            throw new Error('Update failed for user table');
           }
         });
 

--- a/seeders/20200128023056-demo-user.js
+++ b/seeders/20200128023056-demo-user.js
@@ -1,35 +1,35 @@
 'use strict';
 
 module.exports = {
-  up: (queryInterface, Sequelize) => {
+  up: (queryInterface) => {
     return queryInterface.bulkInsert('users', [
       {
         name: 'John Doe',
         email: 'example@example.com',
-        accessLevel: "COMMANDER",
+        accessLevel: 'COMMANDER',
         emergencyContact: '1234567890',
         createdAt: new Date(),
-        updatedAt: new Date()
+        updatedAt: new Date(),
       },
       {
         name: 'Clark Kent',
         email: 'clark.kent@example.com',
-        accessLevel: "SUPERVISOR",
+        accessLevel: 'SUPERVISOR',
         emergencyContact: '1234567890',
         createdAt: new Date(),
-        updatedAt: new Date()
+        updatedAt: new Date(),
       },
       {
         name: 'Chris Paul',
         email: 'chris.paul@example.com',
-        accessLevel: "ADMIN",
+        accessLevel: 'ADMIN',
         emergencyContact: '1234567890',
         createdAt: new Date(),
-        updatedAt: new Date()
-      }
+        updatedAt: new Date(),
+      },
     ]);
   },
-  down: (queryInterface, Sequelize) => {
+  down: (queryInterface) => {
     return queryInterface.bulkDelete('users', null, {});
-  }
+  },
 };

--- a/seeders/20200129021755-events.js
+++ b/seeders/20200129021755-events.js
@@ -1,19 +1,19 @@
-"use strict";
+'use strict';
 
-const db = require("../models");
+const db = require('../models');
 
 module.exports = {
-  up: async (queryInterface, Sequelize) => {
+  up: async (queryInterface) => {
     const user = await db.user.create({
-      name: "Capt Holt",
-      email: "capt.holt@asd.com",
-      accessLevel: "COMMANDER",
-      password: "asdfgh1234",
+      name: 'Capt Holt',
+      email: 'capt.holt@asd.com',
+      accessLevel: 'COMMANDER',
+      password: 'asdfgh1234',
       createdAt: new Date(),
-      updatedAt: new Date()
+      updatedAt: new Date(),
     });
 
-    return queryInterface.bulkInsert("events", [
+    return queryInterface.bulkInsert('events', [
       {
         name: "St Patrick's Day",
         eventDate: new Date(),
@@ -23,16 +23,16 @@ module.exports = {
         updatedAt: new Date(),
       },
       {
-        name: "Homecoming",
+        name: 'Homecoming',
         eventDate: new Date(),
         createdBy: user.id,
         isActive: true,
         createdAt: new Date(),
         updatedAt: new Date(),
-      }
+      },
     ]);
   },
-  down: (queryInterface, Sequelize) => {
-    return queryInterface.bulkDelete("events", null, {});
-  }
+  down: (queryInterface) => {
+    return queryInterface.bulkDelete('events', null, {});
+  },
 };

--- a/seeders/20200206002553-demo-collectionPoint.js
+++ b/seeders/20200206002553-demo-collectionPoint.js
@@ -3,50 +3,43 @@
 const db = require('../models');
 
 module.exports = {
-  up: async (queryInterface, Sequelize) => {
+  up: async (queryInterface) => {
     const user = await db.user.create({
-      name: "Firas Mansour",
-      email: "mansour_is_a_cool_guy@gmail.com",
-      accessLevel: "SUPERVISOR",
-      password: "asdfgh1234",
+      name: 'Firas Mansour',
+      email: 'mansour_is_a_cool_guy@gmail.com',
+      accessLevel: 'SUPERVISOR',
+      password: 'asdfgh1234',
       createdAt: new Date(),
-      updatedAt: new Date()
+      updatedAt: new Date(),
     });
 
     const event = await db.event.create({
       eventDate: new Date(),
-      name: "St. Patricks",
+      name: 'St. Patricks',
       createdBy: user.id,
       isActive: true,
       createdAt: new Date(),
-      updatedAt: new Date()
-
+      updatedAt: new Date(),
     });
-    return queryInterface.bulkInsert('collectionPoints', [{
-      name: 'Checkpoint 0',
-      eventId: event.id,
-      createdBy: user.id,
-      createdAt: new Date(),
-      updatedAt: new Date()
-    },
-    {
-      name: 'Checkpoint 1',
-      eventId: event.id,
-      createdBy: user.id,
-      createdAt: new Date(),
-      updatedAt: new Date()
-
-    },
+    return queryInterface.bulkInsert('collectionPoints', [
+      {
+        name: 'Checkpoint 0',
+        eventId: event.id,
+        createdBy: user.id,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        name: 'Checkpoint 1',
+        eventId: event.id,
+        createdBy: user.id,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
     ]);
-
   },
 
-  down: (queryInterface, Sequelize) => {
-    /*
-      Add reverting commands here.
-      Return a promise to correctly handle asynchronicity.
-    */
+  down: (queryInterface) => {
     return queryInterface.bulkDelete('collectionPoints', null, {});
-
-  }
+  },
 };

--- a/seeders/20200206005427-demo-patient.js
+++ b/seeders/20200206005427-demo-patient.js
@@ -1,21 +1,21 @@
-"use strict";
+'use strict';
 
-const db = require("../models");
+const db = require('../models');
 
 module.exports = {
-  up: async (queryInterface, Sequelize) => {
+  up: async (queryInterface) => {
     const user = await db.user.create({
-      name: "Darth Vader",
-      email: "darthvader@sithlords.com",
-      accessLevel: "COMMANDER",
-      password: "ga1axyru1er",
+      name: 'Darth Vader',
+      email: 'darthvader@sithlords.com',
+      accessLevel: 'COMMANDER',
+      password: 'ga1axyru1er',
       createdAt: new Date(),
       updatedAt: new Date(),
     });
 
     const event = await db.event.create({
       eventDate: new Date(),
-      name: "Death Star Launch Day",
+      name: 'Death Star Launch Day',
       createdBy: user.id,
       isActive: true,
       createdAt: new Date(),
@@ -23,47 +23,47 @@ module.exports = {
     });
 
     const collectionPoint = await db.collectionPoint.create({
-      name: "Checkpoint Tatooine",
+      name: 'Checkpoint Tatooine',
       eventId: event.id,
       createdBy: user.id,
       createdAt: new Date(),
       updatedAt: new Date(),
     });
 
-    return queryInterface.bulkInsert("patients", [
+    return queryInterface.bulkInsert('patients', [
       {
-        gender: "Male",
+        gender: 'Male',
         age: 19,
-        barcodeValue: "1525242sa",
+        barcodeValue: '1525242sa',
         collectionPointId: collectionPoint.id,
-        status: "ON_SITE",
-        triageLevel: "YELLOW",
-        notes: "This guy looks super drunk",
+        status: 'ON_SITE',
+        triageLevel: 'YELLOW',
+        notes: 'This guy looks super drunk',
         transportTime: new Date(),
         createdAt: new Date(),
         updatedAt: new Date(),
       },
       {
-        gender: "Female",
+        gender: 'Female',
         runNumber: 65433,
-        barcodeValue: "9876F5E4",
+        barcodeValue: '9876F5E4',
         collectionPointId: collectionPoint.id,
-        status: "RELEASED",
+        status: 'RELEASED',
         triageCategory: 1,
-        triageLevel: "GREEN",
-        notes: "needs a bandaid has green lightsaber",
+        triageLevel: 'GREEN',
+        notes: 'needs a bandaid has green lightsaber',
         createdAt: new Date(),
         updatedAt: new Date(),
       },
       {
-        gender: "unknown",
+        gender: 'unknown',
         age: 21,
         runNumber: 65433,
-        barcodeValue: "9876FY54",
+        barcodeValue: '9876FY54',
         collectionPointId: collectionPoint.id,
-        status: "TRANSPORTED",
+        status: 'TRANSPORTED',
         triageCategory: 3,
-        triageLevel: "BLACK",
+        triageLevel: 'BLACK',
         transportTime: new Date(),
         createdAt: new Date(),
         updatedAt: new Date(),
@@ -71,7 +71,7 @@ module.exports = {
     ]);
   },
 
-  down: (queryInterface, Sequelize) => {
-    return queryInterface.bulkDelete("patients", null, {});
+  down: (queryInterface) => {
+    return queryInterface.bulkDelete('patients', null, {});
   },
 };

--- a/seeders/20200213002509-demo-hospital.js
+++ b/seeders/20200213002509-demo-hospital.js
@@ -1,27 +1,31 @@
 'use strict';
 
 module.exports = {
-  up: (queryInterface, Sequelize) => {
-      return queryInterface.bulkInsert('hospitals', [
+  up: (queryInterface) => {
+    return queryInterface.bulkInsert(
+      'hospitals',
+      [
         {
           name: 'Hospital 1',
           createdAt: new Date(),
-          updatedAt: new Date()
+          updatedAt: new Date(),
         },
         {
           name: 'Hospital 2',
           createdAt: new Date(),
-          updatedAt: new Date()
+          updatedAt: new Date(),
         },
         {
           name: 'Hospital 3',
           createdAt: new Date(),
-          updatedAt: new Date()
-        }
-    ], {});
+          updatedAt: new Date(),
+        },
+      ],
+      {}
+    );
   },
 
-  down: (queryInterface, Sequelize) => {
-      return queryInterface.bulkDelete('hospitals', null, {});
-  }
+  down: (queryInterface) => {
+    return queryInterface.bulkDelete('hospitals', null, {});
+  },
 };

--- a/seeders/20200213020630-demo-ambulance.js
+++ b/seeders/20200213020630-demo-ambulance.js
@@ -1,27 +1,31 @@
 'use strict';
 
 module.exports = {
-  up: (queryInterface, Sequelize) => {
-    return queryInterface.bulkInsert('ambulances', [
-      {
-        vehicleNumber: 1234,
-        createdAt: new Date(),
-        updatedAt: new Date()
-      },
-      {
-        vehicleNumber: 4567,
-        createdAt: new Date(),
-        updatedAt: new Date()
-      },
-      {
-        vehicleNumber: 8910,
-        createdAt: new Date(),
-        updatedAt: new Date()
-      }
-  ], {});
+  up: (queryInterface) => {
+    return queryInterface.bulkInsert(
+      'ambulances',
+      [
+        {
+          vehicleNumber: 1234,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          vehicleNumber: 4567,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          vehicleNumber: 8910,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ],
+      {}
+    );
   },
 
-  down: (queryInterface, Sequelize) => {
+  down: (queryInterface) => {
     return queryInterface.bulkDelete('ambulances', null, {});
-  }
+  },
 };

--- a/seeders/20200609004045-EventAmbulances.js
+++ b/seeders/20200609004045-EventAmbulances.js
@@ -1,75 +1,76 @@
 'use strict';
 
-const db = require("../models");
+const db = require('../models');
 
 module.exports = {
-  up: async (queryInterface, Sequelize) => {
+  up: async (queryInterface) => {
     const user = await db.user.create({
-      name: "Jane Doe",
-      email: "janedoe@gmail.com",
-      accessLevel: "SUPERVISOR",
-      password: "asdfgh1234",
+      name: 'Jane Doe',
+      email: 'janedoe@gmail.com',
+      accessLevel: 'SUPERVISOR',
+      password: 'asdfgh1234',
       createdAt: new Date(),
-      updatedAt: new Date()
+      updatedAt: new Date(),
     });
 
     const event1 = await db.event.create({
       eventDate: new Date(),
-      name: "Big Bad Event #1",
+      name: 'Big Bad Event #1',
       createdBy: user.id,
       isActive: true,
       createdAt: new Date(),
-      updatedAt: new Date()
+      updatedAt: new Date(),
     });
 
     const event2 = await db.event.create({
       eventDate: new Date(),
-      name: "Big Bad Event #2",
+      name: 'Big Bad Event #2',
       createdBy: user.id,
       isActive: true,
       createdAt: new Date(),
-      updatedAt: new Date()
+      updatedAt: new Date(),
     });
 
     const ambulance1 = await db.ambulance.create({
       vehicleNumber: 890,
       createdAt: new Date(),
-      updatedAt: new Date()
+      updatedAt: new Date(),
     });
 
     const ambulance2 = await db.ambulance.create({
       vehicleNumber: 891,
       createdAt: new Date(),
-      updatedAt: new Date()
+      updatedAt: new Date(),
     });
 
-    return queryInterface.bulkInsert('eventAmbulances', [{
-      eventId: event1.id,
-      ambulanceId: ambulance1.id,
-      createdAt: new Date(),
-      updatedAt: new Date()
-    },
-    {
-      eventId: event1.id,
-      ambulanceId: ambulance2.id,
-      createdAt: new Date(),
-      updatedAt: new Date()
-    },
-    {
-      eventId: event2.id,
-      ambulanceId: ambulance1.id,
-      createdAt: new Date(),
-      updatedAt: new Date()
-    },
-    {
-      eventId: event2.id,
-      ambulanceId: ambulance2.id,
-      createdAt: new Date(),
-      updatedAt: new Date()
-    },
+    return queryInterface.bulkInsert('eventAmbulances', [
+      {
+        eventId: event1.id,
+        ambulanceId: ambulance1.id,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        eventId: event1.id,
+        ambulanceId: ambulance2.id,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        eventId: event2.id,
+        ambulanceId: ambulance1.id,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        eventId: event2.id,
+        ambulanceId: ambulance2.id,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
     ]);
   },
-  down: (queryInterface, Sequelize) => {
+  down: (queryInterface) => {
     return queryInterface.bulkDelete('eventAmbulances', null, {});
-  }
+  },
 };

--- a/seeders/20200609004052-EventHospitals.js
+++ b/seeders/20200609004052-EventHospitals.js
@@ -1,75 +1,76 @@
 'use strict';
 
-const db = require("../models");
+const db = require('../models');
 
 module.exports = {
-  up: async (queryInterface, Sequelize) => {
+  up: async (queryInterface) => {
     const user = await db.user.create({
-      name: "Jill Doe",
-      email: "jilldoe@gmail.com",
-      accessLevel: "COMMANDER",
-      password: "asdfgh1234",
+      name: 'Jill Doe',
+      email: 'jilldoe@gmail.com',
+      accessLevel: 'COMMANDER',
+      password: 'asdfgh1234',
       createdAt: new Date(),
-      updatedAt: new Date()
+      updatedAt: new Date(),
     });
 
     const event1 = await db.event.create({
       eventDate: new Date(),
-      name: "Big Bad Event #3",
+      name: 'Big Bad Event #3',
       createdBy: user.id,
       isActive: true,
       createdAt: new Date(),
-      updatedAt: new Date()
+      updatedAt: new Date(),
     });
 
     const event2 = await db.event.create({
       eventDate: new Date(),
-      name: "Big Bad Event #4",
+      name: 'Big Bad Event #4',
       createdBy: user.id,
       isActive: true,
       createdAt: new Date(),
-      updatedAt: new Date()
+      updatedAt: new Date(),
     });
 
     const hospital1 = await db.hospital.create({
       name: "Waterloo's Best Hospital 1",
       createdAt: new Date(),
-      updatedAt: new Date()
+      updatedAt: new Date(),
     });
 
     const hospital2 = await db.hospital.create({
       name: "Waterloo's Best Hospital 2",
       createdAt: new Date(),
-      updatedAt: new Date()
+      updatedAt: new Date(),
     });
 
-    return queryInterface.bulkInsert('eventHospitals', [{
-      eventId: event1.id,
-      hospitalId: hospital1.id,
-      createdAt: new Date(),
-      updatedAt: new Date()
-    },
-    {
-      eventId: event1.id,
-      hospitalId: hospital2.id,
-      createdAt: new Date(),
-      updatedAt: new Date()
-    },
-    {
-      eventId: event2.id,
-      hospitalId: hospital1.id,
-      createdAt: new Date(),
-      updatedAt: new Date()
-    },
-    {
-      eventId: event2.id,
-      hospitalId: hospital2.id,
-      createdAt: new Date(),
-      updatedAt: new Date()
-    },
+    return queryInterface.bulkInsert('eventHospitals', [
+      {
+        eventId: event1.id,
+        hospitalId: hospital1.id,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        eventId: event1.id,
+        hospitalId: hospital2.id,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        eventId: event2.id,
+        hospitalId: hospital1.id,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        eventId: event2.id,
+        hospitalId: hospital2.id,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
     ]);
   },
-  down: (queryInterface, Sequelize) => {
+  down: (queryInterface) => {
     return queryInterface.bulkDelete('eventHospitals', null, {});
-  }
+  },
 };

--- a/seeders/20200717011432-locationPins.js
+++ b/seeders/20200717011432-locationPins.js
@@ -1,13 +1,13 @@
-"use strict";
+'use strict';
 
 module.exports = {
-  up: (queryInterface, Sequelize) => {
-    return queryInterface.bulkInsert("locationPins", [
+  up: (queryInterface) => {
+    return queryInterface.bulkInsert('locationPins', [
       {
         latitude: 65.679012,
         longitude: -60.68729,
-        label: "Pin 1",
-        address: "Test Address 1",
+        label: 'Pin 1',
+        address: 'Test Address 1',
         eventId: 1,
         createdAt: new Date(),
         updatedAt: new Date(),
@@ -15,8 +15,8 @@ module.exports = {
       {
         latitude: 10.2392,
         longitude: 76.989,
-        label: "Pin 2",
-        address: "Test Address 2",
+        label: 'Pin 2',
+        address: 'Test Address 2',
         eventId: 1,
         createdAt: new Date(),
         updatedAt: new Date(),
@@ -24,15 +24,15 @@ module.exports = {
       {
         latitude: 60.891,
         longitude: 60.891,
-        label: "Pin 3",
-        address: "Test Address 3",
+        label: 'Pin 3',
+        address: 'Test Address 3',
         eventId: 1,
         createdAt: new Date(),
         updatedAt: new Date(),
       },
     ]);
   },
-  down: (queryInterface, Sequelize) => {
-    return queryInterface.bulkDelete("locationPins", null, {});
+  down: (queryInterface) => {
+    return queryInterface.bulkDelete('locationPins', null, {});
   },
 };

--- a/server.js
+++ b/server.js
@@ -6,5 +6,6 @@ const { schema } = require('./graphql');
 const server = new ApolloServer({ schema });
 
 server.listen().then(({ url }) => {
+  // eslint-disable-next-line no-console
   console.log(`🚀 Server ready at ${url}`);
 });


### PR DESCRIPTION
## Overview
>[Code review doc for reference](https://www.notion.so/uwblueprintexecs/Code-Review-a21fc85b00394f488e92d9d605f6b2bc)

[Notion task](https://www.notion.so/uwblueprintexecs/docker-linter-setup-e63c6fbc895b4f4e904e228bab13582b)

**SEE MY INLINE COMMENTS FOR MOST RELEVANT CHANGES**

## Changes
- linted all files based on linter set up in this commit: https://github.com/uwblueprint/paramedics-web/commit/6c05f55f53b0c6d9042e1d5ba5f46aea1c5e486f
  - refactored some code for linting and performance
- reverted `eventAmbulances` and `eventHospitals` tables to be non-paranoid
  - refactored `addAmbulancesToEvent` and `addHospitalsToEvent` as they were really unwieldy with soft deletes
- set up `dev-lint` job in circleCI
  - refactored existing jobs/steps for performance
    - `dev-build` builds using dev dockerfile
    - `prod-build` builds using prod dockerfile (new)
    - `dev-lint` lints using dev dockerfile as that's where we installed eslint (new)
    - removed `install` step as it wasn't doing anything

## Testing
- running `npm run lint` locally (or via vscode) has no errors
- verify that existing resolvers are working as expected (especially `event`)
- test out `addAmbulancesToEvent` and `addHospitalsToEvent`
  - add and delete resources and check the db tables to make sure all changes look correct
- look with your eyes at the checks on this PR and see that all jobs have a green check mark

## Notes
- we should move towards preferring promise chaining over `await` statements - the latter can still be used when necessary
- in general, our CI/CD pipeline is really small and thus fairly fast - we can break down the steps in our `docker-compose` file and optimize even more for performance, but it's not that expensive (i.e. slow) to just do everything from scratch with each build
- not entirely convinced that the caching within jobs are even doing anything - removed for now
  - this is related to the fact that we simply use `docker-compose up` to build the container, which would not get the benefit of caching `package-lock.json` - we could optimize by breaking it down into discrete steps ([more info here](https://circleci.com/docs/2.0/caching/#section=projects))