### PR TITLE
Fixing restoration resolvers

### DIFF
--- a/models/user.js
+++ b/models/user.js
@@ -13,7 +13,7 @@ module.exports = (sequelize, DataTypes) => {
       password: DataTypes.STRING,
       emergencyContact: DataTypes.STRING,
     },
-    {}
+    { paranoid: true }
   );
   return User;
 };

--- a/resolvers/ambulance.js
+++ b/resolvers/ambulance.js
@@ -55,27 +55,29 @@ const ambulanceResolvers = {
       return db.ambulance.findByPk(args.id);
     },
     deleteAmbulance: async (parent, args) => {
-      await Promise.all([
-        db.patient
-          .count({
-            where: {
-              ambulanceId: args.id,
-            },
-          })
-          .then((count) => {
-            if (count > 0) {
-              throw new Error(
-                'Deletion failed; there are associated patients for ambulance ID: ' +
-                  args.id
-              );
-            }
-          }),
-        db.eventAmbulances.destroy({
+      await db.patient
+        .count({
           where: {
             ambulanceId: args.id,
           },
-        }),
-      ]);
+        })
+        .then((count) => {
+          if (count > 0) {
+            throw new Error(
+              'Deletion failed; there are associated patients for ambulance ID: ' +
+                args.id
+            );
+          }
+        })
+        .catch((error) => {
+          throw error;
+        });
+
+      await db.eventAmbulances.destroy({
+        where: {
+          ambulanceId: args.id,
+        },
+      });
 
       return db.ambulance.destroy({
         where: {

--- a/resolvers/ambulance.js
+++ b/resolvers/ambulance.js
@@ -45,13 +45,13 @@ const ambulanceResolvers = {
           return db.ambulance.findByPk(args.id);
         }),
     restoreAmbulance: async (parent, args) => {
-      await db.ambulance.restore({
-        where: {
-          id: args.id,
-        },
-      });
-
-      return db.ambulance.findByPk(args.id);
+      return db.ambulance
+        .restore({
+          where: {
+            id: args.id,
+          },
+        })
+        .then(() => db.ambulance.findByPk(args.id));
     },
     deleteAmbulance: async (parent, args) => {
       await Promise.all([

--- a/resolvers/ambulance.js
+++ b/resolvers/ambulance.js
@@ -45,39 +45,11 @@ const ambulanceResolvers = {
           return db.ambulance.findByPk(args.id);
         }),
     restoreAmbulance: async (parent, args) => {
-      await Promise.all([
-        db.ambulance.restore({
-          where: {
-            id: args.id,
-          },
-        }),
-        // Restoring event association if event also availiable
-        db.eventAmbulances
-          .findAll({
-            where: {
-              ambulanceId: args.id,
-            },
-            include: [
-              {
-                model: db.event,
-                required: true,
-              },
-            ],
-            paranoid: false,
-          })
-          .then((associatedEvents) =>
-            Promise.all(
-              associatedEvents.map((associatedEvent) =>
-                db.eventAmbulances.restore({
-                  where: {
-                    eventId: associatedEvent.eventId,
-                    ambulanceId: args.id,
-                  },
-                })
-              )
-            )
-          ),
-      ]);
+      await db.ambulance.restore({
+        where: {
+          id: args.id,
+        },
+      });
 
       return db.ambulance.findByPk(args.id);
     },

--- a/resolvers/ambulance.js
+++ b/resolvers/ambulance.js
@@ -27,7 +27,7 @@ const ambulanceResolvers = {
       db.ambulance.create({
         vehicleNumber: args.vehicleNumber,
       }),
-    updateAmbulance: (parent, args) => {
+    updateAmbulance: (parent, args) =>
       db.ambulance
         .update(
           {
@@ -44,12 +44,9 @@ const ambulanceResolvers = {
             throw new Error('Failed update for ambulance ID: ' + args.id);
           }
           return db.ambulance.findByPk(args.id);
-        });
-    },
+        }),
     restoreAmbulance: async (parent, args) => {
-      await validators.validateAmbulance(args.id, true).catch((error) => {
-        throw error;
-      });
+      await validators.validateAmbulance(args.id, true);
       await db.ambulance.restore({
         where: {
           id: args.id,

--- a/resolvers/ambulance.js
+++ b/resolvers/ambulance.js
@@ -45,6 +45,14 @@ const ambulanceResolvers = {
           return db.ambulance.findByPk(args.id);
         }),
     restoreAmbulance: async (parent, args) => {
+      await db.ambulance
+        .findByPk(args.id, { paranoid: false })
+        .then((ambulance) => {
+          if (!ambulance) {
+            throw new Error('Invalid ambulance: ' + args.id);
+          }
+        });
+
       return db.ambulance
         .restore({
           where: {

--- a/resolvers/ambulance.js
+++ b/resolvers/ambulance.js
@@ -68,9 +68,6 @@ const ambulanceResolvers = {
                 args.id
             );
           }
-        })
-        .catch((error) => {
-          throw error;
         });
 
       await db.eventAmbulances.destroy({

--- a/resolvers/collectionPoint.js
+++ b/resolvers/collectionPoint.js
@@ -61,15 +61,24 @@ const collectionPointResolvers = {
         });
       return db.collectionPoint.findByPk(args.id);
     },
-    restoreCollectionPoint: (parent, args) =>
-      db.collectionPoint
+    restoreCollectionPoint: async (parent, args) => {
+      await db.collectionPoint
+        .findByPk(args.id, { paranoid: false })
+        .then((ccp) => {
+          if (!ccp) {
+            throw new Error('Invalid collection point: ' + args.id);
+          }
+        });
+
+      return db.collectionPoint
         .restore({
           where: {
             id: args.id,
           },
           individualHooks: true,
         })
-        .then(() => db.collectionPoint.findByPk(args.id)),
+        .then(() => db.collectionPoint.findByPk(args.id));
+    },
     deleteCollectionPoint: (parent, args) =>
       // Return status for destroy
       // 1 for successful deletion, 0 otherwise

--- a/resolvers/collectionPoint.js
+++ b/resolvers/collectionPoint.js
@@ -62,22 +62,17 @@ const collectionPointResolvers = {
       return db.collectionPoint.findByPk(args.id);
     },
     restoreCollectionPoint: async (parent, args) => {
-      await db.collectionPoint
-        .findByPk(args.id, { paranoid: false })
-        .then((ccp) => {
-          if (!ccp) {
-            throw new Error('Invalid collection point: ' + args.id);
-          }
-        });
+      await validators.validateCollectionPoint(args.id, true).catch((error) => {
+        throw error;
+      });
 
-      return db.collectionPoint
-        .restore({
-          where: {
-            id: args.id,
-          },
-          individualHooks: true,
-        })
-        .then(() => db.collectionPoint.findByPk(args.id));
+      await db.collectionPoint.restore({
+        where: {
+          id: args.id,
+        },
+        individualHooks: true,
+      });
+      return db.collectionPoint.findByPk(args.id);
     },
     deleteCollectionPoint: (parent, args) =>
       // Return status for destroy

--- a/resolvers/collectionPoint.js
+++ b/resolvers/collectionPoint.js
@@ -62,9 +62,7 @@ const collectionPointResolvers = {
       return db.collectionPoint.findByPk(args.id);
     },
     restoreCollectionPoint: async (parent, args) => {
-      await validators.validateCollectionPoint(args.id, true).catch((error) => {
-        throw error;
-      });
+      await validators.validateCollectionPoint(args.id, true);
 
       await db.collectionPoint.restore({
         where: {

--- a/resolvers/collectionPoint.js
+++ b/resolvers/collectionPoint.js
@@ -63,7 +63,6 @@ const collectionPointResolvers = {
     },
     restoreCollectionPoint: async (parent, args) => {
       await validators.validateCollectionPoint(args.id, true);
-
       await db.collectionPoint.restore({
         where: {
           id: args.id,

--- a/resolvers/event.js
+++ b/resolvers/event.js
@@ -295,9 +295,7 @@ const eventResolvers = {
       });
     },
     restoreEvent: async (parent, args) => {
-      await validators.validateEvent(args.id, true).catch((error) => {
-        throw error;
-      });
+      await validators.validateEvent(args.id, true);
       await db.event.restore({
         where: {
           id: args.id,

--- a/resolvers/event.js
+++ b/resolvers/event.js
@@ -294,7 +294,16 @@ const eventResolvers = {
         ],
       });
     },
+    restoreEvent: async (parent, args) => {
+      await db.event.restore({
+        where: {
+          id: args.id,
+        },
+        individualHooks: true,
+      });
 
+      return db.event.findByPk(args.id);
+    },
     deleteEvent: async (parent, args) => {
       // Return status for destroy
       // 1 for successful deletion, 0 otherwise

--- a/resolvers/event.js
+++ b/resolvers/event.js
@@ -295,14 +295,14 @@ const eventResolvers = {
       });
     },
     restoreEvent: async (parent, args) => {
-      await db.event.restore({
-        where: {
-          id: args.id,
-        },
-        individualHooks: true,
-      });
-
-      return db.event.findByPk(args.id);
+      return db.event
+        .restore({
+          where: {
+            id: args.id,
+          },
+          individualHooks: true,
+        })
+        .then(() => db.event.findByPk(args.id));
     },
     deleteEvent: async (parent, args) => {
       // Return status for destroy

--- a/resolvers/event.js
+++ b/resolvers/event.js
@@ -295,6 +295,12 @@ const eventResolvers = {
       });
     },
     restoreEvent: async (parent, args) => {
+      await db.event.findByPk(args.id, { paranoid: false }).then((event) => {
+        if (!event) {
+          throw new Error('Invalid event: ' + args.id);
+        }
+      });
+
       return db.event
         .restore({
           where: {

--- a/resolvers/event.js
+++ b/resolvers/event.js
@@ -295,20 +295,16 @@ const eventResolvers = {
       });
     },
     restoreEvent: async (parent, args) => {
-      await db.event.findByPk(args.id, { paranoid: false }).then((event) => {
-        if (!event) {
-          throw new Error('Invalid event: ' + args.id);
-        }
+      await validators.validateEvent(args.id, true).catch((error) => {
+        throw error;
       });
-
-      return db.event
-        .restore({
-          where: {
-            id: args.id,
-          },
-          individualHooks: true,
-        })
-        .then(() => db.event.findByPk(args.id));
+      await db.event.restore({
+        where: {
+          id: args.id,
+        },
+        individualHooks: true,
+      });
+      return db.event.findByPk(args.id);
     },
     deleteEvent: async (parent, args) => {
       // Return status for destroy

--- a/resolvers/hospital.js
+++ b/resolvers/hospital.js
@@ -46,9 +46,7 @@ const hospitalResolvers = {
           return db.hospital.findByPk(args.id);
         }),
     restoreHospital: async (parent, args) => {
-      await validators.validateHospital(args.id, true).catch((error) => {
-        throw error;
-      });
+      await validators.validateHospital(args.id, true);
       await db.hospital.restore({
         where: {
           id: args.id,

--- a/resolvers/hospital.js
+++ b/resolvers/hospital.js
@@ -45,6 +45,13 @@ const hospitalResolvers = {
           return db.hospital.findByPk(args.id);
         }),
     restoreHospital: async (parent, args) => {
+      await db.hospital
+        .findByPk(args.id, { paranoid: false })
+        .then((hospital) => {
+          if (!hospital) {
+            throw new Error('Invalid hospital: ' + args.id);
+          }
+        });
       return db.hospital
         .restore({
           where: {

--- a/resolvers/hospital.js
+++ b/resolvers/hospital.js
@@ -68,9 +68,6 @@ const hospitalResolvers = {
                 args.id
             );
           }
-        })
-        .catch((error) => {
-          throw error;
         });
       await db.eventHospitals.destroy({
         where: {

--- a/resolvers/hospital.js
+++ b/resolvers/hospital.js
@@ -45,39 +45,11 @@ const hospitalResolvers = {
           return db.hospital.findByPk(args.id);
         }),
     restoreHospital: async (parent, args) => {
-      await Promise.all([
-        db.hospital.restore({
-          where: {
-            id: args.id,
-          },
-        }),
-        // Restoring event association if event is also avaliable
-        db.eventHospitals
-          .findAll({
-            where: {
-              hospitalId: args.id,
-            },
-            include: [
-              {
-                model: db.event,
-                required: true,
-              },
-            ],
-            paranoid: false,
-          })
-          .then((associatedEvents) =>
-            Promise.all(
-              associatedEvents.map((associatedEvent) =>
-                db.eventHospitals.restore({
-                  where: {
-                    eventId: associatedEvent.eventId,
-                    hospitalId: args.id,
-                  },
-                })
-              )
-            )
-          ),
-      ]);
+      await db.hospital.restore({
+        where: {
+          id: args.id,
+        },
+      });
 
       return db.hospital.findByPk(args.id);
     },

--- a/resolvers/hospital.js
+++ b/resolvers/hospital.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const db = require('../models');
+const validators = require('../utils/validators');
 
 const hospitalResolvers = {
   Query: {
@@ -45,20 +46,15 @@ const hospitalResolvers = {
           return db.hospital.findByPk(args.id);
         }),
     restoreHospital: async (parent, args) => {
-      await db.hospital
-        .findByPk(args.id, { paranoid: false })
-        .then((hospital) => {
-          if (!hospital) {
-            throw new Error('Invalid hospital: ' + args.id);
-          }
-        });
-      return db.hospital
-        .restore({
-          where: {
-            id: args.id,
-          },
-        })
-        .then(() => db.hospital.findByPk(args.id));
+      await validators.validateHospital(args.id, true).catch((error) => {
+        throw error;
+      });
+      await db.hospital.restore({
+        where: {
+          id: args.id,
+        },
+      });
+      return db.hospital.findByPk(args.id);
     },
     deleteHospital: async (parent, args) => {
       await Promise.all([

--- a/resolvers/hospital.js
+++ b/resolvers/hospital.js
@@ -55,27 +55,28 @@ const hospitalResolvers = {
       return db.hospital.findByPk(args.id);
     },
     deleteHospital: async (parent, args) => {
-      await Promise.all([
-        db.patient
-          .count({
-            where: {
-              hospitalId: args.id,
-            },
-          })
-          .then((count) => {
-            if (count > 0) {
-              throw new Error(
-                'Deletion failed; there are associated patients for hospital ID: ' +
-                  args.id
-              );
-            }
-          }),
-        db.eventHospitals.destroy({
+      await db.patient
+        .count({
           where: {
             hospitalId: args.id,
           },
-        }),
-      ]);
+        })
+        .then((count) => {
+          if (count > 0) {
+            throw new Error(
+              'Deletion failed; there are associated patients for hospital ID: ' +
+                args.id
+            );
+          }
+        })
+        .catch((error) => {
+          throw error;
+        });
+      await db.eventHospitals.destroy({
+        where: {
+          hospitalId: args.id,
+        },
+      });
 
       return db.hospital.destroy({
         where: {

--- a/resolvers/hospital.js
+++ b/resolvers/hospital.js
@@ -45,13 +45,13 @@ const hospitalResolvers = {
           return db.hospital.findByPk(args.id);
         }),
     restoreHospital: async (parent, args) => {
-      await db.hospital.restore({
-        where: {
-          id: args.id,
-        },
-      });
-
-      return db.hospital.findByPk(args.id);
+      return db.hospital
+        .restore({
+          where: {
+            id: args.id,
+          },
+        })
+        .then(() => db.hospital.findByPk(args.id));
     },
     deleteHospital: async (parent, args) => {
       await Promise.all([

--- a/resolvers/locationPin.js
+++ b/resolvers/locationPin.js
@@ -61,7 +61,6 @@ const locationPinResolvers = {
     },
     restoreLocationPin: async (parent, args) => {
       await validators.validateLocationPin(args.id, true);
-
       await db.locationPins.restore({
         where: {
           id: args.id,

--- a/resolvers/locationPin.js
+++ b/resolvers/locationPin.js
@@ -60,21 +60,16 @@ const locationPinResolvers = {
       return db.locationPins.findByPk(args.id);
     },
     restoreLocationPin: async (parent, args) => {
-      await db.locationPins
-        .findByPk(args.id, { paranoid: false })
-        .then((locationPin) => {
-          if (!locationPin) {
-            throw new Error('Invalid location pin: ' + args.id);
-          }
-        });
+      await validators.validateLocationPin(args.id, true).catch((error) => {
+        throw error;
+      });
 
-      db.locationPins
-        .restore({
-          where: {
-            id: args.id,
-          },
-        })
-        .then(() => db.locationPins.findByPk(args.id));
+      await db.locationPins.restore({
+        where: {
+          id: args.id,
+        },
+      });
+      return db.locationPins.findByPk(args.id);
     },
     deleteLocationPin: (parent, args) =>
       // Return status for destroy

--- a/resolvers/locationPin.js
+++ b/resolvers/locationPin.js
@@ -60,9 +60,7 @@ const locationPinResolvers = {
       return db.locationPins.findByPk(args.id);
     },
     restoreLocationPin: async (parent, args) => {
-      await validators.validateLocationPin(args.id, true).catch((error) => {
-        throw error;
-      });
+      await validators.validateLocationPin(args.id, true);
 
       await db.locationPins.restore({
         where: {

--- a/resolvers/locationPin.js
+++ b/resolvers/locationPin.js
@@ -59,7 +59,15 @@ const locationPinResolvers = {
         });
       return db.locationPins.findByPk(args.id);
     },
-    restoreLocationPin: (parent, args) => {
+    restoreLocationPin: async (parent, args) => {
+      await db.locationPins
+        .findByPk(args.id, { paranoid: false })
+        .then((locationPin) => {
+          if (!locationPin) {
+            throw new Error('Invalid location pin: ' + args.id);
+          }
+        });
+
       db.locationPins
         .restore({
           where: {

--- a/resolvers/patient.js
+++ b/resolvers/patient.js
@@ -84,7 +84,6 @@ const patientResolvers = {
     },
     restorePatient: async (parent, args) => {
       await validators.validatePatient(args.id, true);
-
       await db.patient.restore({
         where: { id: args.id },
       });

--- a/resolvers/patient.js
+++ b/resolvers/patient.js
@@ -83,9 +83,7 @@ const patientResolvers = {
       return db.patient.findByPk(args.id);
     },
     restorePatient: async (parent, args) => {
-      await validators.validatePatient(args.id, true).catch((error) => {
-        throw error;
-      });
+      await validators.validatePatient(args.id, true);
 
       await db.patient.restore({
         where: { id: args.id },

--- a/resolvers/patient.js
+++ b/resolvers/patient.js
@@ -82,12 +82,21 @@ const patientResolvers = {
       );
       return db.patient.findByPk(args.id);
     },
-    restorePatient: (parent, args) =>
-      db.patient
+    restorePatient: async (parent, args) => {
+      await db.patient
+        .findByPk(args.id, { paranoid: false })
+        .then((patient) => {
+          if (!patient) {
+            throw new Error('Invalid patient: ' + args.id);
+          }
+        });
+
+      return db.patient
         .restore({
           where: { id: args.id },
         })
-        .then(() => db.patient.findByPk(args.id)),
+        .then(() => db.patient.findByPk(args.id));
+    },
     // This is a user delete of a patient, where the status is updated. A system delete happens if a CCP with associated patients is deleted
     deletePatient: (parent, args) =>
       db.patient

--- a/resolvers/patient.js
+++ b/resolvers/patient.js
@@ -83,19 +83,14 @@ const patientResolvers = {
       return db.patient.findByPk(args.id);
     },
     restorePatient: async (parent, args) => {
-      await db.patient
-        .findByPk(args.id, { paranoid: false })
-        .then((patient) => {
-          if (!patient) {
-            throw new Error('Invalid patient: ' + args.id);
-          }
-        });
+      await validators.validatePatient(args.id, true).catch((error) => {
+        throw error;
+      });
 
-      return db.patient
-        .restore({
-          where: { id: args.id },
-        })
-        .then(() => db.patient.findByPk(args.id));
+      await db.patient.restore({
+        where: { id: args.id },
+      });
+      return db.patient.findByPk(args.id);
     },
     // This is a user delete of a patient, where the status is updated. A system delete happens if a CCP with associated patients is deleted
     deletePatient: (parent, args) =>

--- a/resolvers/user.js
+++ b/resolvers/user.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const db = require('../models');
+const validators = require('../utils/validators');
 
 const userResolvers = {
   Query: {
@@ -38,19 +39,15 @@ const userResolvers = {
           return db.user.findByPk(args.id);
         }),
     restoreUser: async (parent, args) => {
-      await db.user.findByPk(args.id, { paranoid: false }).then((user) => {
-        if (!user) {
-          throw new Error('Invalid user: ' + args.id);
-        }
+      await validators.validateUser(args.id, true).catch((error) => {
+        throw error;
       });
-
-      return db.user
-        .restore({
-          where: {
-            id: args.id,
-          },
-        })
-        .then(() => db.user.findByPk(args.id));
+      await db.user.restore({
+        where: {
+          id: args.id,
+        },
+      });
+      return db.user.findByPk(args.id);
     },
     deleteUser: (parent, args) =>
       db.user.destroy({

--- a/resolvers/user.js
+++ b/resolvers/user.js
@@ -37,14 +37,21 @@ const userResolvers = {
           }
           return db.user.findByPk(args.id);
         }),
-    restoreUser: (parent, args) =>
-      db.user
+    restoreUser: async (parent, args) => {
+      await db.user.findByPk(args.id, { paranoid: false }).then((user) => {
+        if (!user) {
+          throw new Error('Invalid user: ' + args.id);
+        }
+      });
+
+      return db.user
         .restore({
           where: {
             id: args.id,
           },
         })
-        .then(() => db.user.findByPk(args.id)),
+        .then(() => db.user.findByPk(args.id));
+    },
     deleteUser: (parent, args) =>
       db.user.destroy({
         where: {

--- a/resolvers/user.js
+++ b/resolvers/user.js
@@ -39,9 +39,7 @@ const userResolvers = {
           return db.user.findByPk(args.id);
         }),
     restoreUser: async (parent, args) => {
-      await validators.validateUser(args.id, true).catch((error) => {
-        throw error;
-      });
+      await validators.validateUser(args.id, true);
       await db.user.restore({
         where: {
           id: args.id,

--- a/schema/event.js
+++ b/schema/event.js
@@ -20,6 +20,7 @@ const eventSchema = `
     addHospitalsToEvent(eventId: ID!, hospitals: [HospitalInput]!): Event
     deleteAmbulancesFromEvent(eventId: ID!, ambulances: [AmbulanceInput]!): Event
     deleteHospitalsFromEvent(eventId: ID!, hospitals: [HospitalInput]!): Event
+    restoreEvent(id: ID!): Event
     deleteEvent(id: ID!): Int!
   }
 

--- a/utils/validators.js
+++ b/utils/validators.js
@@ -4,40 +4,111 @@ const db = require('../models');
 
 // for validating resolver arguments
 module.exports = {
-  validateUser: (userId, errorMessage = 'Invalid user ID: ' + userId) =>
-    db.user.findByPk(userId).then((user) => {
+  validateUser: (
+    userId,
+    checkParanoid = false,
+    errorMessage = 'Invalid user ID: ' + userId
+  ) => {
+    const options = { paranoid: true };
+    if (checkParanoid) {
+      options.paranoid = false;
+    }
+    return db.user.findByPk(userId, options).then((user) => {
       if (!user) {
         throw new Error(errorMessage);
       }
-    }),
-  validateEvent: (eventId, errorMessage = 'Invalid event ID: ' + eventId) =>
-    db.event.findByPk(eventId).then((event) => {
+    });
+  },
+  validateEvent: (
+    eventId,
+    checkParanoid = false,
+    errorMessage = 'Invalid event ID: ' + eventId
+  ) => {
+    const options = { paranoid: true };
+    if (checkParanoid) {
+      options.paranoid = false;
+    }
+    return db.event.findByPk(eventId, options).then((event) => {
       if (!event) {
         throw new Error(errorMessage);
       }
-    }),
-  validateCollectionPoint: (ccpId, errorMessage = 'Invalid CCP ID: ' + ccpId) =>
-    db.collectionPoint.findByPk(ccpId).then((ccp) => {
+    });
+  },
+  validateCollectionPoint: (
+    ccpId,
+    checkParanoid = false,
+    errorMessage = 'Invalid CCP ID: ' + ccpId
+  ) => {
+    const options = { paranoid: true };
+    if (checkParanoid) {
+      options.paranoid = false;
+    }
+    return db.collectionPoint.findByPk(ccpId, options).then((ccp) => {
       if (!ccp) {
         throw new Error(errorMessage);
       }
-    }),
+    });
+  },
   validateAmbulance: (
     ambulanceId,
+    checkParanoid = false,
     errorMessage = 'Invalid ambulance ID: ' + ambulanceId
-  ) =>
-    db.ambulance.findByPk(ambulanceId).then((ambulance) => {
+  ) => {
+    const options = { paranoid: true };
+    if (checkParanoid) {
+      options.paranoid = false;
+    }
+    return db.ambulance.findByPk(ambulanceId, options).then((ambulance) => {
       if (!ambulance) {
         throw new Error(errorMessage);
       }
-    }),
+    });
+  },
   validateHospital: (
     hospitalId,
+    checkParanoid = false,
     errorMessage = 'Invalid hospital ID: ' + hospitalId
-  ) =>
-    db.hospital.findByPk(hospitalId).then((hospital) => {
+  ) => {
+    const options = { paranoid: true };
+    if (checkParanoid) {
+      options.paranoid = false;
+    }
+    return db.hospital.findByPk(hospitalId, options).then((hospital) => {
       if (!hospital) {
         throw new Error(errorMessage);
       }
-    }),
+    });
+  },
+  validatePatient: (
+    patientId,
+    checkParanoid = false,
+    errorMessage = 'Invalid patient ID: ' + patientId
+  ) => {
+    const options = { paranoid: true };
+    if (checkParanoid) {
+      options.paranoid = false;
+    }
+    return db.patient.findByPk(patientId, options).then((patient) => {
+      if (!patient) {
+        throw new Error(errorMessage);
+      }
+    });
+  },
+  validateLocationPin: (
+    locationPinId,
+    checkParanoid = false,
+    errorMessage = 'Invalid location pin ID: ' + locaionPinId
+  ) => {
+    const options = { paranoid: true };
+    if (checkParanoid) {
+      options.paranoid = false;
+    }
+    return db.locationPins
+      .findByPk(locationPinId, options)
+      .then((locationPin) => {
+        if (!locationPin) {
+          throw new Error(errorMessage);
+        }
+      });
+  },
 };

--- a/utils/validators.js
+++ b/utils/validators.js
@@ -13,11 +13,16 @@ module.exports = {
     if (checkParanoid) {
       options.paranoid = false;
     }
-    return db.user.findByPk(userId, options).then((user) => {
-      if (!user) {
-        throw new Error(errorMessage);
-      }
-    });
+    return db.user
+      .findByPk(userId, options)
+      .then((user) => {
+        if (!user) {
+          throw new Error(errorMessage);
+        }
+      })
+      .catch((error) => {
+        throw error;
+      });
   },
   validateEvent: (
     eventId,
@@ -28,11 +33,16 @@ module.exports = {
     if (checkParanoid) {
       options.paranoid = false;
     }
-    return db.event.findByPk(eventId, options).then((event) => {
-      if (!event) {
-        throw new Error(errorMessage);
-      }
-    });
+    return db.event
+      .findByPk(eventId, options)
+      .then((event) => {
+        if (!event) {
+          throw new Error(errorMessage);
+        }
+      })
+      .catch((error) => {
+        throw error;
+      });
   },
   validateCollectionPoint: (
     ccpId,
@@ -43,11 +53,16 @@ module.exports = {
     if (checkParanoid) {
       options.paranoid = false;
     }
-    return db.collectionPoint.findByPk(ccpId, options).then((ccp) => {
-      if (!ccp) {
-        throw new Error(errorMessage);
-      }
-    });
+    return db.collectionPoint
+      .findByPk(ccpId, options)
+      .then((ccp) => {
+        if (!ccp) {
+          throw new Error(errorMessage);
+        }
+      })
+      .catch((error) => {
+        throw error;
+      });
   },
   validateAmbulance: (
     ambulanceId,
@@ -58,11 +73,16 @@ module.exports = {
     if (checkParanoid) {
       options.paranoid = false;
     }
-    return db.ambulance.findByPk(ambulanceId, options).then((ambulance) => {
-      if (!ambulance) {
-        throw new Error(errorMessage);
-      }
-    });
+    return db.ambulance
+      .findByPk(ambulanceId, options)
+      .then((ambulance) => {
+        if (!ambulance) {
+          throw new Error(errorMessage);
+        }
+      })
+      .catch((error) => {
+        throw error;
+      });
   },
   validateHospital: (
     hospitalId,
@@ -73,11 +93,16 @@ module.exports = {
     if (checkParanoid) {
       options.paranoid = false;
     }
-    return db.hospital.findByPk(hospitalId, options).then((hospital) => {
-      if (!hospital) {
-        throw new Error(errorMessage);
-      }
-    });
+    return db.hospital
+      .findByPk(hospitalId, options)
+      .then((hospital) => {
+        if (!hospital) {
+          throw new Error(errorMessage);
+        }
+      })
+      .catch((error) => {
+        throw error;
+      });
   },
   validatePatient: (
     patientId,
@@ -88,11 +113,16 @@ module.exports = {
     if (checkParanoid) {
       options.paranoid = false;
     }
-    return db.patient.findByPk(patientId, options).then((patient) => {
-      if (!patient) {
-        throw new Error(errorMessage);
-      }
-    });
+    return db.patient
+      .findByPk(patientId, options)
+      .then((patient) => {
+        if (!patient) {
+          throw new Error(errorMessage);
+        }
+      })
+      .catch((error) => {
+        throw error;
+      });
   },
   validateLocationPin: (
     locationPinId,
@@ -109,6 +139,9 @@ module.exports = {
         if (!locationPin) {
           throw new Error(errorMessage);
         }
+      })
+      .catch((error) => {
+        throw error;
       });
   },
 };

--- a/utils/validators.js
+++ b/utils/validators.js
@@ -13,16 +13,11 @@ module.exports = {
     if (checkParanoid) {
       options.paranoid = false;
     }
-    return db.user
-      .findByPk(userId, options)
-      .then((user) => {
-        if (!user) {
-          throw new Error(errorMessage);
-        }
-      })
-      .catch((error) => {
-        throw error;
-      });
+    return db.user.findByPk(userId, options).then((user) => {
+      if (!user) {
+        throw new Error(errorMessage);
+      }
+    });
   },
   validateEvent: (
     eventId,
@@ -33,16 +28,11 @@ module.exports = {
     if (checkParanoid) {
       options.paranoid = false;
     }
-    return db.event
-      .findByPk(eventId, options)
-      .then((event) => {
-        if (!event) {
-          throw new Error(errorMessage);
-        }
-      })
-      .catch((error) => {
-        throw error;
-      });
+    return db.event.findByPk(eventId, options).then((event) => {
+      if (!event) {
+        throw new Error(errorMessage);
+      }
+    });
   },
   validateCollectionPoint: (
     ccpId,
@@ -53,16 +43,11 @@ module.exports = {
     if (checkParanoid) {
       options.paranoid = false;
     }
-    return db.collectionPoint
-      .findByPk(ccpId, options)
-      .then((ccp) => {
-        if (!ccp) {
-          throw new Error(errorMessage);
-        }
-      })
-      .catch((error) => {
-        throw error;
-      });
+    return db.collectionPoint.findByPk(ccpId, options).then((ccp) => {
+      if (!ccp) {
+        throw new Error(errorMessage);
+      }
+    });
   },
   validateAmbulance: (
     ambulanceId,
@@ -73,16 +58,11 @@ module.exports = {
     if (checkParanoid) {
       options.paranoid = false;
     }
-    return db.ambulance
-      .findByPk(ambulanceId, options)
-      .then((ambulance) => {
-        if (!ambulance) {
-          throw new Error(errorMessage);
-        }
-      })
-      .catch((error) => {
-        throw error;
-      });
+    return db.ambulance.findByPk(ambulanceId, options).then((ambulance) => {
+      if (!ambulance) {
+        throw new Error(errorMessage);
+      }
+    });
   },
   validateHospital: (
     hospitalId,
@@ -93,16 +73,11 @@ module.exports = {
     if (checkParanoid) {
       options.paranoid = false;
     }
-    return db.hospital
-      .findByPk(hospitalId, options)
-      .then((hospital) => {
-        if (!hospital) {
-          throw new Error(errorMessage);
-        }
-      })
-      .catch((error) => {
-        throw error;
-      });
+    return db.hospital.findByPk(hospitalId, options).then((hospital) => {
+      if (!hospital) {
+        throw new Error(errorMessage);
+      }
+    });
   },
   validatePatient: (
     patientId,
@@ -113,16 +88,11 @@ module.exports = {
     if (checkParanoid) {
       options.paranoid = false;
     }
-    return db.patient
-      .findByPk(patientId, options)
-      .then((patient) => {
-        if (!patient) {
-          throw new Error(errorMessage);
-        }
-      })
-      .catch((error) => {
-        throw error;
-      });
+    return db.patient.findByPk(patientId, options).then((patient) => {
+      if (!patient) {
+        throw new Error(errorMessage);
+      }
+    });
   },
   validateLocationPin: (
     locationPinId,
@@ -139,9 +109,6 @@ module.exports = {
         if (!locationPin) {
           throw new Error(errorMessage);
         }
-      })
-      .catch((error) => {
-        throw error;
       });
   },
 };

--- a/utils/validators.js
+++ b/utils/validators.js
@@ -97,7 +97,7 @@ module.exports = {
   validateLocationPin: (
     locationPinId,
     checkParanoid = false,
-    errorMessage = 'Invalid location pin ID: ' + locaionPinId
+    errorMessage = 'Invalid location pin ID: ' + locationPinId
   ) => {
     const options = { paranoid: true };
     if (checkParanoid) {


### PR DESCRIPTION
## Overview
>[Code review doc for reference](https://www.notion.so/uwblueprintexecs/Code-Review-a21fc85b00394f488e92d9d605f6b2bc)

This PR addresses two tickets:
[Ticket 1](https://www.notion.so/uwblueprintexecs/396370c5e09f4c28bc7f455a7e84c908?v=3751aa62a2594c74b7e0ecb363304c24&p=a2659349008a4914af16de78e596ba6b)
[Ticket 2](https://www.notion.so/uwblueprintexecs/396370c5e09f4c28bc7f455a7e84c908?v=3751aa62a2594c74b7e0ecb363304c24&p=54566102e29f49b3aeaca7a4d50055d5)

<b>Before reviewing this PR, please review the following documentation:</b>
1. [Paranoid tables](https://www.notion.so/uwblueprintexecs/6a0ad062ce504acc90fa25cb4d2c731f?v=4844a823da724b7ebf2c442a1ee1279f&p=4fabc50d4a9b4c969c96d7ae5bc19cfc)
2. [Deletion & restoration decisions](https://www.notion.so/uwblueprintexecs/6a0ad062ce504acc90fa25cb4d2c731f?v=4844a823da724b7ebf2c442a1ee1279f&p=a0701ccd6ca64c01898f09cd61ccfb8b)

## Changes
- Re-added `restoreEvent` resolver which exclusively restores the event and cascade restore any associated entities (not including resources)
- Changed `restoreAmbulance` and `restoreHospital` mutations so that it exclusively restores the entity and not the event-resource association
- Added error checking for all restoration resolvers

## Testing
Please perform the following tests:
1. Delete an event, confirm that the event is not returned in a query, restore an event and confirm that the event is now present in the query
2. Delete an event and confirm the following through queries:
    1. All associated collection points are deleted
    2. All associated patients are deleted
    Once confirmed, restore the event and confirm that associated collection points and patients are also restored
3. Navigate to the database and query `eventAmbulance` and `eventHospital` to determine the associations between events and ambulances. Then, delete an event, check that the associations are deleted in the `eventAmbulance` and `eventHospital` tables, restore the event, and check that the associations were NOT restored
4. Delete an ambulance, check the `eventAmbulance` table to confirm associations are deleted, restore the ambulance and check that the associations in the `eventAmbulance` table are NOT restored
5. Perform test case 5 using hospitals and the `eventHospital` junction table
6. Make sure that the association between events and hospitals/ambulance is NOT deleted when hospitals/ambulances already have patients. Perform the following steps:
    1. Perform `updatePatient` and add some patient to an ambulance/hospital
    2. Add the ambulance/hospital to an event by performing `addAmbulancesToEvent` or `addHospitalsToEvent`
    3. Try deleting the ambulance/hospital. An error should pop up
    4. Ensure that that the association is not deleted by querying `events` again and ensure that the results have not changed

Here is a GIF of me performing test 3 on for `eventAmbulance`:
![Kapture 2020-09-11 at 12 01 37](https://user-images.githubusercontent.com/21224282/92957970-aad14f00-f426-11ea-8bcf-0babcd7f8f5e.gif)
