### PR TITLE
Returning patient object from deletion resolver

### DIFF
--- a/resolvers/patient.js
+++ b/resolvers/patient.js
@@ -90,8 +90,8 @@ const patientResolvers = {
       return db.patient.findByPk(args.id);
     },
     // This is a user delete of a patient, where the status is updated. A system delete happens if a CCP with associated patients is deleted
-    deletePatient: (parent, args) =>
-      db.patient
+    deletePatient: async (parent, args) => {
+      await db.patient
         .update(
           {
             status: 'DELETED',
@@ -105,7 +105,9 @@ const patientResolvers = {
             return args.id;
           }
           throw new Error('Deletion failed for patient ID: ' + args.id);
-        }),
+        });
+      return db.patient.findByPk(args.id);
+    },
   },
 };
 

--- a/resolvers/patient.js
+++ b/resolvers/patient.js
@@ -90,8 +90,8 @@ const patientResolvers = {
       return db.patient.findByPk(args.id);
     },
     // This is a user delete of a patient, where the status is updated. A system delete happens if a CCP with associated patients is deleted
-    deletePatient: async (parent, args) => {
-      await db.patient
+    deletePatient: (parent, args) =>
+      db.patient
         .update(
           {
             status: 'DELETED',
@@ -102,12 +102,10 @@ const patientResolvers = {
         )
         .then((isDeleted) => {
           if (isDeleted[0] === 1) {
-            return args.id;
+            return db.patient.findByPk(args.id);
           }
           throw new Error('Deletion failed for patient ID: ' + args.id);
-        });
-      return db.patient.findByPk(args.id);
-    },
+        }),
   },
 };
 

--- a/schema/patient.js
+++ b/schema/patient.js
@@ -59,7 +59,7 @@ const patientSchema = `
 
     restorePatient(id: ID!): Patient!
 
-    deletePatient(id: ID!): ID!
+    deletePatient(id: ID!): Patient!
   }
   
   type Patient {


### PR DESCRIPTION
[Notion ticket](https://www.notion.so/uwblueprintexecs/9224caeb21ce4350b8a1dc378d393323?v=43f44ac04d734394b7f7edc636c523b4)

## Changes
- Returning an entire patient object from the deletion resolver rather than only it's ID
    - Motivation: we need to update the cache on the frontend, which requires conforming to the 'edit cache' pattern where we need to return both the ID as well as the fields that we have changed. This allows us to do the latter
## Screenshots
Querying the status from a deleted patient: 
<img width="1016" alt="Screen Shot 2020-10-06 at 8 31 13 PM" src="https://user-images.githubusercontent.com/21224282/95280713-e76c4c80-0812-11eb-8962-5d72a4f4c028.png">
## Testing
1. Make sure that you can query <b>all</b> fields from the returned patient entity
2. Create/update a patient and perform test 1 again

## Checklist
>[Code review doc for reference](https://www.notion.so/uwblueprintexecs/Code-Review-a21fc85b00394f488e92d9d605f6b2bc)

before opening PR
- [ ] check notion ticket
- [ ] run linter
- [ x ] go through file diff

filling out PR
- [x] descriptive title
- [ ] update `notion ticket` link
- [x] fill out `Changes`
  - [x] \(optional) add inline comments in diff
- [x] fill out `Testing`
- [x] \(optional) add `Screenshots`
- [x] assign yourself to the PR

after opening PR
- [ ] link PR to notion ticket
- [ ] move ticket to `In PR`
- [x] make sure build passes
- [x] ping `@ps` in `#paramedics-dev`
