### PR TITLE
Update -1 runNumbers to null

### DIFF
--- a/migrations/20201121211100-update negative runNumbers to null.js
+++ b/migrations/20201121211100-update negative runNumbers to null.js
@@ -8,7 +8,5 @@ module.exports = {
       { runNumber: '-1' }
     );
   },
-  down: () => {
-    return Promise.resolve();
-  },
+  down: () => Promise.resolve(),
 };

--- a/migrations/20201121211100-update negative runNumbers to null.js
+++ b/migrations/20201121211100-update negative runNumbers to null.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface) => {
+    return queryInterface.bulkUpdate(
+      'patients',
+      { runNumber: null },
+      { runNumber: '-1' }
+    );
+  },
+  down: () => {
+    return Promise.resolve();
+  },
+};


### PR DESCRIPTION
[Notion ticket](https://www.notion.so/uwblueprintexecs/run-numbers-1-8475f8a7003b4829a24275262ba3f4b8)

Related frontend ticket: https://github.com/uwblueprint/paramedics-react/pull/61

## Changes
- Migration updates all patients whose `runNumber` is -1 to null

## Testing
- Add/edit patients to have `runNumber` = -1
- Run migration and check DB to see that all those `runNumber` are now null

## Checklist
>[Code review doc for reference](https://www.notion.so/uwblueprintexecs/Code-Review-a21fc85b00394f488e92d9d605f6b2bc)

before opening PR
- [x] check notion ticket
- [x] run linter
- [x] go through file diff

filling out PR
- [x] descriptive title
- [x] update `notion ticket` link
- [x] fill out `Changes`
  - [ ] \(optional) add inline comments in diff
- [x] fill out `Testing`
- [ ] \(optional) add `Screenshots`
- [x] assign yourself to the PR

after opening PR
- [x] link PR to notion ticket
- [x] move ticket to `In PR`
- [x] make sure build passes
- [x] ping `@ps` in `#paramedics-dev`
