### PR TITLE
RTU Stage 2 changes

### DIFF
--- a/schema/patient.js
+++ b/schema/patient.js
@@ -63,10 +63,10 @@ const patientSchema = `
   }
   
   type Subscription {
-    patientAdded(collectionPointId: ID!): Patient
-    patientUpdated(collectionPointId: ID!): Patient
-    patientDeleted(collectionPointId: ID!): Patient
-    patientRestored(collectionPointId: ID!): Patient
+    patientAdded(eventId: ID!): Patient
+    patientUpdated(eventId: ID!): Patient
+    patientDeleted(eventId: ID!): Patient
+    patientRestored(eventId: ID!): Patient
   }
 
   type Patient {


### PR DESCRIPTION
[Notion ticket](https://www.notion.so/uwblueprintexecs/RTU-Stage-3-Push-updates-to-CCP-dashboard-d350cbe422d446d5a45114d5b931c962)

Linked to uwblueprint/paramedics-react#63 (RTU Stage 2 Front End changes)

## Changes
- updates subscriptions to be subscribed by eventId instead of ccpId, so client can receive RTU for patients at all CCPs at a given event. (paramedics will be able to switch between CCP dashboards and have the up-to-date information for all tables)

## Screenshots
<img width="1394" alt="image" src="https://user-images.githubusercontent.com/38408276/99936437-273eb300-2d31-11eb-886f-a78c49628191.png">
<img width="1394" alt="image" src="https://user-images.githubusercontent.com/38408276/99936452-3160b180-2d31-11eb-9e31-603fd133cb8a.png">
<img width="1394" alt="image" src="https://user-images.githubusercontent.com/38408276/99936470-37ef2900-2d31-11eb-9727-4a069c3307c8.png">

## Testing
- You can test this out on the frontend, just checkout the jl-rtu-stage2 branch and refer to this PR uwblueprint/paramedics-react#63
- In graphql playground, write out subscription along with any patient fields you want returned (examples above), 
- Make sure if the patient you're adding/editing has a collectionPointId belonging to the event you're subscribed to
- Check that subscriptions listens for the corresponding mutations, e.g. try adding/updating/deleting a patient from the graphQL playground

## Checklist
>[Code review doc for reference](https://www.notion.so/uwblueprintexecs/Code-Review-a21fc85b00394f488e92d9d605f6b2bc)

before opening PR
- [x] check notion ticket
- [x] run linter
- [x] go through file diff

filling out PR
- [x] descriptive title
- [x] update `notion ticket` link
- [x] fill out `Changes`
  - [ ] \(optional) add inline comments in diff
- [x] fill out `Testing`
- [x] \(optional) add `Screenshots`
- [x] assign yourself to the PR

after opening PR
- [x] link PR to notion ticket
- [x] move ticket to `In PR`
- [x] make sure build passes
- [x] ping `@ps` in `#paramedics-dev`
