### PR TITLE
Adding backend support for different location pin types

### DIFF
--- a/migrations/20201125223742-add-pin-type-and-parent-id.js
+++ b/migrations/20201125223742-add-pin-type-and-parent-id.js
@@ -1,0 +1,30 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction((t) => {
+      return Promise.all([
+        queryInterface.addColumn('locationPins', 'pinType', {
+          type: Sequelize.DataTypes.ENUM('EVENT', 'CCP', 'OTHER'),
+        }, {transaction: t}),
+        queryInterface.addColumn('locationPins', 'ccpParentId', {
+          type: Sequelize.INTEGER,
+        }, {transaction: t}),
+        queryInterface.addColumn('locationPins', 'eventParentId', {
+          type: Sequelize.INTEGER,
+        }, {transaction: t})
+      ])
+    })
+  },
+
+  down: (queryInterface) => {
+    return queryInterface.sequelize.transaction((t) => {
+      return Promise.all([
+        queryInterface.removeColumn('locationPins', 'eventParentId', {transaction: t}),
+        queryInterface.removeColumn('locationPins', 'ccpParentId', {transaction: t}),
+        queryInterface.removeColumn('locationPins', 'pinType', {transaction: t}),
+        queryInterface.sequelize.query('DROP TYPE IF EXISTS "enum_locationPins_pinType"', {transaction: t}),
+      ])
+    })
+  }
+};

--- a/migrations/20201125223742-add-pin-type-and-parent-id.js
+++ b/migrations/20201125223742-add-pin-type-and-parent-id.js
@@ -9,39 +9,37 @@ module.exports = {
           'pinType',
           {
             type: Sequelize.DataTypes.ENUM('EVENT', 'CCP', 'OTHER'),
+            defaultValue: 'OTHER',
           },
           { transaction: t }
         ),
         queryInterface.addColumn(
           'locationPins',
-          'ccpParentId',
+          'ccpId',
           {
             type: Sequelize.INTEGER,
           },
           { transaction: t }
         ),
-      ]).then(() => {
-        queryInterface.sequelize.query(
-          `UPDATE "locationPins" SET "pinType" = 'OTHER' WHERE "pinType" IS NULL`
-        );
-      });
+      ]);
     });
   },
 
   down: (queryInterface) => {
     return queryInterface.sequelize.transaction((t) => {
       return Promise.all([
-        queryInterface.removeColumn('locationPins', 'ccpParentId', {
+        queryInterface.removeColumn('locationPins', 'ccpId', {
           transaction: t,
         }),
         queryInterface.removeColumn('locationPins', 'pinType', {
           transaction: t,
         }),
+      ]).then(() =>
         queryInterface.sequelize.query(
           'DROP TYPE IF EXISTS "enum_locationPins_pinType"',
           { transaction: t }
-        ),
-      ]);
+        )
+      );
     });
   },
 };

--- a/migrations/20201125223742-add-pin-type-and-parent-id.js
+++ b/migrations/20201125223742-add-pin-type-and-parent-id.js
@@ -4,27 +4,44 @@ module.exports = {
   up: (queryInterface, Sequelize) => {
     return queryInterface.sequelize.transaction((t) => {
       return Promise.all([
-        queryInterface.addColumn('locationPins', 'pinType', {
-          type: Sequelize.DataTypes.ENUM('EVENT', 'CCP', 'OTHER'),
-        }, {transaction: t}),
-        queryInterface.addColumn('locationPins', 'ccpParentId', {
-          type: Sequelize.INTEGER,
-        }, {transaction: t}),
-        queryInterface.addColumn('locationPins', 'eventParentId', {
-          type: Sequelize.INTEGER,
-        }, {transaction: t})
-      ])
-    })
+        queryInterface.addColumn(
+          'locationPins',
+          'pinType',
+          {
+            type: Sequelize.DataTypes.ENUM('EVENT', 'CCP', 'OTHER'),
+          },
+          { transaction: t }
+        ),
+        queryInterface.addColumn(
+          'locationPins',
+          'ccpParentId',
+          {
+            type: Sequelize.INTEGER,
+          },
+          { transaction: t }
+        ),
+      ]).then(() => {
+        queryInterface.sequelize.query(
+          `UPDATE "locationPins" SET "pinType" = 'OTHER' WHERE "pinType" IS NULL`
+        );
+      });
+    });
   },
 
   down: (queryInterface) => {
     return queryInterface.sequelize.transaction((t) => {
       return Promise.all([
-        queryInterface.removeColumn('locationPins', 'eventParentId', {transaction: t}),
-        queryInterface.removeColumn('locationPins', 'ccpParentId', {transaction: t}),
-        queryInterface.removeColumn('locationPins', 'pinType', {transaction: t}),
-        queryInterface.sequelize.query('DROP TYPE IF EXISTS "enum_locationPins_pinType"', {transaction: t}),
-      ])
-    })
-  }
+        queryInterface.removeColumn('locationPins', 'ccpParentId', {
+          transaction: t,
+        }),
+        queryInterface.removeColumn('locationPins', 'pinType', {
+          transaction: t,
+        }),
+        queryInterface.sequelize.query(
+          'DROP TYPE IF EXISTS "enum_locationPins_pinType"',
+          { transaction: t }
+        ),
+      ]);
+    });
+  },
 };

--- a/models/locationPins.js
+++ b/models/locationPins.js
@@ -14,7 +14,6 @@ module.exports = (sequelize, DataTypes) => {
         values: ['OTHER', 'CCP', 'EVENT'],
       },
       ccpParentId: DataTypes.INTEGER,
-      eventParentId: DataTypes.INTEGER,
     },
     { paranoid: true }
   );
@@ -23,11 +22,6 @@ module.exports = (sequelize, DataTypes) => {
 
     locationPin.belongsTo(models.event, {
       foreignKey: 'eventId',
-      targetKey: 'id',
-    });
-
-    locationPin.belongsTo(models.event, {
-      foreignKey: 'eventParentId',
       targetKey: 'id',
     });
 

--- a/models/locationPins.js
+++ b/models/locationPins.js
@@ -13,7 +13,7 @@ module.exports = (sequelize, DataTypes) => {
         type: DataTypes.ENUM,
         values: ['OTHER', 'CCP', 'EVENT'],
       },
-      ccpParentId: DataTypes.INTEGER,
+      ccpId: DataTypes.INTEGER,
     },
     { paranoid: true }
   );
@@ -26,7 +26,7 @@ module.exports = (sequelize, DataTypes) => {
     });
 
     locationPin.belongsTo(models.collectionPoint, {
-      foreignKey: 'ccpParentId',
+      foreignKey: 'ccpId',
       targetKey: 'id',
     });
   };

--- a/models/locationPins.js
+++ b/models/locationPins.js
@@ -9,6 +9,12 @@ module.exports = (sequelize, DataTypes) => {
       latitude: DataTypes.FLOAT,
       longitude: DataTypes.FLOAT,
       address: DataTypes.STRING,
+      pinType: {
+        type: DataTypes.ENUM,
+        values: ['OTHER', 'CCP', 'EVENT'],
+      },
+      ccpParentId: DataTypes.INTEGER,
+      eventParentId: DataTypes.INTEGER,
     },
     { paranoid: true }
   );
@@ -17,6 +23,16 @@ module.exports = (sequelize, DataTypes) => {
 
     locationPin.belongsTo(models.event, {
       foreignKey: 'eventId',
+      targetKey: 'id',
+    });
+
+    locationPin.belongsTo(models.event, {
+      foreignKey: 'eventParentId',
+      targetKey: 'id',
+    });
+
+    locationPin.belongsTo(models.collectionPoint, {
+      foreignKey: 'ccpParentId',
       targetKey: 'id',
     });
   };

--- a/resolvers/locationPin.js
+++ b/resolvers/locationPin.js
@@ -29,8 +29,8 @@ const locationPinResolvers = {
       validators.validateRole(Object.values(Roles), validators.demoRole);
       return db.event.findByPk(parent.eventId);
     },
-    ccpParentId: (parent) => {
-      return db.collectionPoint.findByPk(parent.ccpParentId);
+    ccpId: (parent) => {
+      return db.collectionPoint.findByPk(parent.ccpId);
     },
   },
 
@@ -42,14 +42,9 @@ const locationPinResolvers = {
         validators.demoRole
       );
       await validators.validateEvent(args.eventId);
-      if (args.ccpParentId) {
-        await validators.validateCollectionPoint(args.ccpParentId);
-      }
 
       await validators.validateLocationPin({
-        pinType: args.pinType,
-        ccpParentId: args.ccpParentId,
-        eventId: args.eventId,
+        args: args,
         newPin: true,
       });
 
@@ -73,11 +68,7 @@ const locationPinResolvers = {
       }
 
       await validators.validateLocationPin({
-        locationPinId: args.id,
-        pinType: args.pinType,
-        ccpParentId: args.ccpParentId,
-        eventId: args.eventId,
-        errorMessage: 'Invalid location pin ID: ' + args.id,
+        args: args,
       });
 
       await db.locationPins
@@ -110,11 +101,7 @@ const locationPinResolvers = {
         validators.demoRole
       );
       await validators.validateLocationPin({
-        locationPinId: args.id,
-        pinType: args.pinType,
-        ccpParentId: args.ccpParentId,
-        eventId: args.eventId,
-        errorMessage: 'Invalid location pin ID: ' + args.id,
+        args: args,
         checkParanoid: true,
       });
 

--- a/resolvers/locationPin.js
+++ b/resolvers/locationPin.js
@@ -29,12 +29,9 @@ const locationPinResolvers = {
       validators.validateRole(Object.values(Roles), validators.demoRole);
       return db.event.findByPk(parent.eventId);
     },
-    eventParentId: (parent) => {
-      return db.event.findByPk(parent.eventId);
-    },
     ccpParentId: (parent) => {
       return db.event.findByPk(parent.eventId);
-    }
+    },
   },
 
   // CRUD Operations
@@ -45,11 +42,17 @@ const locationPinResolvers = {
         validators.demoRole
       );
       await validators.validateEvent(args.eventId);
-      if(args.ccpParentId) {
+      if (args.ccpParentId) {
         await validators.validateCollectionPoint(args.ccpParentId);
       }
 
-      await validators.validateLocationPin(args.pinType, args.ccpParentId, args.eventParentId, args.eventId, true);
+      await validators.validateLocationPin(
+        0,
+        args.pinType,
+        args.ccpParentId,
+        args.eventId,
+        true
+      );
       return db.locationPins.create({
         label: args.label,
         eventId: args.eventId,
@@ -58,7 +61,6 @@ const locationPinResolvers = {
         address: args.address,
         pinType: args.pinType,
         ccpParentId: args.ccpParentId,
-        eventParentId: args.eventParentId,
       });
     },
     updateLocationPin: async (parent, args) => {
@@ -70,6 +72,13 @@ const locationPinResolvers = {
         await validators.validateEvent(args.eventId);
       }
 
+      await validators.validateLocationPin(
+        args.id,
+        args.pinType,
+        args.ccpParentId,
+        args.eventId
+      );
+
       await db.locationPins
         .update(
           {
@@ -80,7 +89,6 @@ const locationPinResolvers = {
             address: args.address,
             pinType: args.pinType,
             ccpParentId: args.ccpParentId,
-            eventParentId: args.eventParentId,
           },
           {
             where: {
@@ -100,7 +108,7 @@ const locationPinResolvers = {
         [Roles.COMMANDER, Roles.SUPERVISOR],
         validators.demoRole
       );
-      await validators.validateLocationPin(args.id, true);
+      await validators.validateLocationPin(args.id, 'OTHER', 0, 0, false, true);
       await db.locationPins.restore({
         where: {
           id: args.id,

--- a/resolvers/locationPin.js
+++ b/resolvers/locationPin.js
@@ -29,6 +29,12 @@ const locationPinResolvers = {
       validators.validateRole(Object.values(Roles), validators.demoRole);
       return db.event.findByPk(parent.eventId);
     },
+    eventParentId: (parent) => {
+      return db.event.findByPk(parent.eventId);
+    },
+    ccpParentId: (parent) => {
+      return db.event.findByPk(parent.eventId);
+    }
   },
 
   // CRUD Operations
@@ -43,8 +49,7 @@ const locationPinResolvers = {
         await validators.validateCollectionPoint(args.ccpParentId);
       }
 
-      await validators.validateLocationPin(args.pinType, args.ccpParentId, args.eventId, args.eventId, true);
-
+      await validators.validateLocationPin(args.pinType, args.ccpParentId, args.eventParentId, args.eventId, true);
       return db.locationPins.create({
         label: args.label,
         eventId: args.eventId,

--- a/resolvers/locationPin.js
+++ b/resolvers/locationPin.js
@@ -117,7 +117,7 @@ const locationPinResolvers = {
         errorMessage: 'Invalid location pin ID: ' + args.id,
         checkParanoid: true,
       });
-      
+
       await db.locationPins.restore({
         where: {
           id: args.id,

--- a/resolvers/locationPin.js
+++ b/resolvers/locationPin.js
@@ -27,7 +27,6 @@ const locationPinResolvers = {
   LocationPin: {
     eventId: (parent) => {
       validators.validateRole(Object.values(Roles), validators.demoRole);
-
       return db.event.findByPk(parent.eventId);
     },
   },
@@ -40,6 +39,11 @@ const locationPinResolvers = {
         validators.demoRole
       );
       await validators.validateEvent(args.eventId);
+      if(args.ccpParentId) {
+        await validators.validateCollectionPoint(args.ccpParentId);
+      }
+
+      await validators.validateLocationPin(args.pinType, args.ccpParentId, args.eventId, args.eventId, true);
 
       return db.locationPins.create({
         label: args.label,
@@ -47,6 +51,9 @@ const locationPinResolvers = {
         latitude: args.latitude,
         longitude: args.longitude,
         address: args.address,
+        pinType: args.pinType,
+        ccpParentId: args.ccpParentId,
+        eventParentId: args.eventParentId,
       });
     },
     updateLocationPin: async (parent, args) => {
@@ -66,6 +73,9 @@ const locationPinResolvers = {
             latitude: args.latitude,
             longitude: args.longitude,
             address: args.address,
+            pinType: args.pinType,
+            ccpParentId: args.ccpParentId,
+            eventParentId: args.eventParentId,
           },
           {
             where: {

--- a/resolvers/locationPin.js
+++ b/resolvers/locationPin.js
@@ -46,13 +46,13 @@ const locationPinResolvers = {
         await validators.validateCollectionPoint(args.ccpParentId);
       }
 
-      await validators.validateLocationPin(
-        0,
-        args.pinType,
-        args.ccpParentId,
-        args.eventId,
-        true
-      );
+      await validators.validateLocationPin({
+        pinType: args.pinType,
+        ccpParentId: args.ccpParentId,
+        eventId: args.eventId,
+        newPin: true,
+      });
+
       return db.locationPins.create({
         label: args.label,
         eventId: args.eventId,
@@ -72,12 +72,13 @@ const locationPinResolvers = {
         await validators.validateEvent(args.eventId);
       }
 
-      await validators.validateLocationPin(
-        args.id,
-        args.pinType,
-        args.ccpParentId,
-        args.eventId
-      );
+      await validators.validateLocationPin({
+        locationPinId: args.id,
+        pinType: args.pinType,
+        ccpParentId: args.ccpParentId,
+        eventId: args.eventId,
+        errorMessage: 'Invalid location pin ID: ' + args.id,
+      });
 
       await db.locationPins
         .update(
@@ -108,7 +109,15 @@ const locationPinResolvers = {
         [Roles.COMMANDER, Roles.SUPERVISOR],
         validators.demoRole
       );
-      await validators.validateLocationPin(args.id, 'OTHER', 0, 0, false, true);
+      await validators.validateLocationPin({
+        locationPinId: args.id,
+        pinType: args.pinType,
+        ccpParentId: args.ccpParentId,
+        eventId: args.eventId,
+        errorMessage: 'Invalid location pin ID: ' + args.id,
+        checkParanoid: true,
+      });
+      
       await db.locationPins.restore({
         where: {
           id: args.id,

--- a/resolvers/locationPin.js
+++ b/resolvers/locationPin.js
@@ -30,7 +30,7 @@ const locationPinResolvers = {
       return db.event.findByPk(parent.eventId);
     },
     ccpParentId: (parent) => {
-      return db.event.findByPk(parent.eventId);
+      return db.collectionPoint.findByPk(parent.ccpParentId);
     },
   },
 

--- a/schema/locationPin.js
+++ b/schema/locationPin.js
@@ -12,8 +12,8 @@ const locationPinSchema = `
   }
 
   extend type Mutation {
-    addLocationPin(label: String, eventId: ID!, latitude: Float!, longitude: Float!, address: String, pinType: pinType!, ccpParentId: ID): LocationPin!
-    updateLocationPin(id: ID!, eventId: ID, label: String, latitude: Float, longitude: Float, address: String, pinType: pinType, ccpParentId: ID): LocationPin!
+    addLocationPin(label: String, eventId: ID!, latitude: Float!, longitude: Float!, address: String, pinType: pinType!, ccpId: ID): LocationPin!
+    updateLocationPin(id: ID!, eventId: ID, label: String, latitude: Float, longitude: Float, address: String, pinType: pinType, ccpId: ID): LocationPin!
     restoreLocationPin(id: ID!): LocationPin!
     deleteLocationPin(id: ID!): ID!
   }
@@ -25,7 +25,7 @@ const locationPinSchema = `
     latitude: Float!
     longitude: Float!
     pinType: pinType!
-    ccpParentId: collectionPoint
+    ccpId: collectionPoint
     address: String
     createdAt: DateTime!
     updatedAt: DateTime!

--- a/schema/locationPin.js
+++ b/schema/locationPin.js
@@ -1,4 +1,10 @@
 const locationPinSchema = `
+  enum pinType {
+    EVENT
+    CCP
+    OTHER
+  }
+
   extend type Query {
     pin(id: ID!): LocationPin
     pins: [LocationPin]
@@ -6,8 +12,8 @@ const locationPinSchema = `
   }
 
   extend type Mutation {
-    addLocationPin(label: String, eventId: ID!, latitude: Float!, longitude: Float!, address: String): LocationPin!
-    updateLocationPin(id: ID!, eventId: ID, label: String, latitude: Float, longitude: Float, address: String): LocationPin!
+    addLocationPin(label: String, eventId: ID!, latitude: Float!, longitude: Float!, address: String, pinType: pinType!, eventParentId: ID, ccpParentId: ID): LocationPin!
+    updateLocationPin(id: ID!, eventId: ID, label: String, latitude: Float, longitude: Float, address: String, pinType: pinType, eventParentId: ID, ccpParentId: ID): LocationPin!
     restoreLocationPin(id: ID!): LocationPin!
     deleteLocationPin(id: ID!): ID!
   }
@@ -18,6 +24,9 @@ const locationPinSchema = `
     label: String
     latitude: Float!
     longitude: Float!
+    pinType: pinType!
+    eventParentId: Event
+    ccpParentId: collectionPoint
     address: String
     createdAt: DateTime!
     updatedAt: DateTime!

--- a/schema/locationPin.js
+++ b/schema/locationPin.js
@@ -12,8 +12,8 @@ const locationPinSchema = `
   }
 
   extend type Mutation {
-    addLocationPin(label: String, eventId: ID!, latitude: Float!, longitude: Float!, address: String, pinType: pinType!, eventParentId: ID, ccpParentId: ID): LocationPin!
-    updateLocationPin(id: ID!, eventId: ID, label: String, latitude: Float, longitude: Float, address: String, pinType: pinType, eventParentId: ID, ccpParentId: ID): LocationPin!
+    addLocationPin(label: String, eventId: ID!, latitude: Float!, longitude: Float!, address: String, pinType: pinType!, ccpParentId: ID): LocationPin!
+    updateLocationPin(id: ID!, eventId: ID, label: String, latitude: Float, longitude: Float, address: String, pinType: pinType, ccpParentId: ID): LocationPin!
     restoreLocationPin(id: ID!): LocationPin!
     deleteLocationPin(id: ID!): ID!
   }
@@ -25,7 +25,6 @@ const locationPinSchema = `
     latitude: Float!
     longitude: Float!
     pinType: pinType!
-    eventParentId: Event
     ccpParentId: collectionPoint
     address: String
     createdAt: DateTime!

--- a/seeders/20200717011432-seed-pins.js
+++ b/seeders/20200717011432-seed-pins.js
@@ -7,7 +7,7 @@ module.exports = {
     const user = await db.user.create({
       name: 'Scary Supervisor',
       email: 'space_garbage@gmail.com',
-      roleId: 2,
+      roleId: 1,
       createdAt: new Date(),
       updatedAt: new Date(),
     });
@@ -21,6 +21,13 @@ module.exports = {
       updatedAt: new Date(),
     });
 
+    const collectionPoint = await db.collectionPoint.create({
+      name: 'Checkpoint Coruscant',
+      eventId: event.id,
+      createdBy: user.id,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
     return queryInterface.bulkInsert('locationPins', [
       {
         latitude: 43.470648,
@@ -28,6 +35,7 @@ module.exports = {
         label: 'Pin 1',
         address: 'Test Address 1',
         eventId: event.id,
+        pinType: 'OTHER',
         createdAt: new Date(),
         updatedAt: new Date(),
       },
@@ -37,6 +45,8 @@ module.exports = {
         label: 'Pin 2',
         address: 'Test Address 2',
         eventId: event.id,
+        pinType: 'EVENT',
+        eventParentId: event.id,
         createdAt: new Date(),
         updatedAt: new Date(),
       },
@@ -45,6 +55,8 @@ module.exports = {
         longitude: -80.534324,
         label: 'Pin 3',
         address: 'Test Address 3',
+        pinType: 'CCP',
+        ccpParentId: collectionPoint.id,
         eventId: event.id,
         createdAt: new Date(),
         updatedAt: new Date(),

--- a/seeders/20200717011432-seed-pins.js
+++ b/seeders/20200717011432-seed-pins.js
@@ -46,7 +46,6 @@ module.exports = {
         address: 'Test Address 2',
         eventId: event.id,
         pinType: 'EVENT',
-        eventParentId: event.id,
         createdAt: new Date(),
         updatedAt: new Date(),
       },

--- a/seeders/20200717011432-seed-pins.js
+++ b/seeders/20200717011432-seed-pins.js
@@ -55,7 +55,7 @@ module.exports = {
         label: 'Pin 3',
         address: 'Test Address 3',
         pinType: 'CCP',
-        ccpParentId: collectionPoint.id,
+        ccpId: collectionPoint.id,
         eventId: event.id,
         createdAt: new Date(),
         updatedAt: new Date(),

--- a/utils/validators.js
+++ b/utils/validators.js
@@ -97,41 +97,38 @@ module.exports = {
     });
   },
   validateLocationPin: (
-    locationPinId = 0,
-    pinType = 'OTHER',
-    ccpParentId = 1,
-    eventId = 1,
-    newPin = false,
-    checkParanoid = false,
-    errorMessage = 'Invalid location pin ID: ' + locationPinId
+    params
   ) => {
     const options = { paranoid: true };
-    if (checkParanoid) {
+
+    if (params.checkParanoid) {
       options.paranoid = false;
     }
 
-    if (pinType === 'CCP') {
-      if (!ccpParentId) {
+    if (params.pinType === 'CCP') {
+      if (!params.ccpParentId) {
         throw new Error('A CCP pin must be created by a valid CCP');
       }
     }
-
-    if (pinType === 'EVENT') {
-      if (!eventId) {
+    
+    if (params.pinType === 'EVENT') {
+      console.log(params.eventId);
+      console.log(params.ccpParentId);
+      if (!params.eventId) {
         throw new Error('An event pin must be created by a valid event');
       }
 
-      if (ccpParentId) {
+      if (params.ccpParentId) {
         throw new Error('An event pin cannot be created by a CCP');
       }
     }
 
-    if (!newPin) {
+    if (!params.newPin) {
       return db.locationPins
-        .findByPk(locationPinId, options)
+        .findByPk(params.locationPinId, options)
         .then((locationPin) => {
           if (!locationPin) {
-            throw new Error(errorMessage);
+            throw new Error(params.errorMessage);
           }
         });
     }

--- a/utils/validators.js
+++ b/utils/validators.js
@@ -96,9 +96,7 @@ module.exports = {
       }
     });
   },
-  validateLocationPin: (
-    params
-  ) => {
+  validateLocationPin: (params) => {
     const options = { paranoid: true };
 
     if (params.checkParanoid) {
@@ -110,10 +108,8 @@ module.exports = {
         throw new Error('A CCP pin must be created by a valid CCP');
       }
     }
-    
+
     if (params.pinType === 'EVENT') {
-      console.log(params.eventId);
-      console.log(params.ccpParentId);
       if (!params.eventId) {
         throw new Error('An event pin must be created by a valid event');
       }

--- a/utils/validators.js
+++ b/utils/validators.js
@@ -97,21 +97,54 @@ module.exports = {
     });
   },
   validateLocationPin: (
-    locationPinId,
+    locationPinId = 0,
+    pinType,
+    ccpParentId,
+    eventParentId,
+    eventId,
+    newPin = false,
     checkParanoid = false,
     errorMessage = 'Invalid location pin ID: ' + locationPinId
   ) => {
+    console.log(pinType);
     const options = { paranoid: true };
     if (checkParanoid) {
       options.paranoid = false;
     }
-    return db.locationPins
+
+    if(pinType === 'CCP') {
+      if(!ccpParentId) {
+        throw new Error('A CCP pin must be created by a valid CCP');
+      }
+
+      if(eventParentId) {
+        throw new Error('A CCP pin cannot be created by an event');
+      }
+    }
+
+    if(pinType === 'EVENT') {
+      if(!eventParentId) {
+        throw new Error('An event pin must be created by a valid event');
+      }
+
+      if (eventParentId !== eventId) {
+        throw new Error('An event pin must be created by the same associated event');
+      }
+      
+      if(ccpParentId) {
+        throw new Error('An event pin cannot be created by a CCP');
+      }
+    }
+    
+    if(!newPin) {
+      return db.locationPins
       .findByPk(locationPinId, options)
       .then((locationPin) => {
         if (!locationPin) {
           throw new Error(errorMessage);
         }
       });
+    }
   },
   validateRole: (
     role,

--- a/utils/validators.js
+++ b/utils/validators.js
@@ -98,53 +98,45 @@ module.exports = {
   },
   validateLocationPin: (
     locationPinId = 0,
-    pinType,
-    ccpParentId,
-    eventParentId,
-    eventId,
+    pinType = 'OTHER',
+    ccpParentId = 1,
+    eventId = 1,
     newPin = false,
     checkParanoid = false,
     errorMessage = 'Invalid location pin ID: ' + locationPinId
   ) => {
-
     const options = { paranoid: true };
     if (checkParanoid) {
       options.paranoid = false;
     }
 
-    if(pinType === 'CCP') {
-      if(!ccpParentId) {
+    if (pinType === 'CCP') {
+      if (!ccpParentId) {
         throw new Error('A CCP pin must be created by a valid CCP');
-      }
-
-      if(eventParentId) {
-        throw new Error('A CCP pin cannot be created by an event');
       }
     }
 
-    if(pinType === 'EVENT') {
-      if(!eventParentId) {
+    if (pinType === 'EVENT') {
+      if (!eventId) {
         throw new Error('An event pin must be created by a valid event');
       }
 
-      if (eventParentId !== eventId) {
-        throw new Error('An event pin must be created by the same associated event');
-      }
-      
-      if(ccpParentId) {
+      if (ccpParentId) {
         throw new Error('An event pin cannot be created by a CCP');
       }
     }
 
-    if(!newPin) {
+    if (!newPin) {
       return db.locationPins
-      .findByPk(locationPinId, options)
-      .then((locationPin) => {
-        if (!locationPin) {
-          throw new Error(errorMessage);
-        }
-      });
+        .findByPk(locationPinId, options)
+        .then((locationPin) => {
+          if (!locationPin) {
+            throw new Error(errorMessage);
+          }
+        });
     }
+
+    return true;
   },
   validateRole: (
     role,

--- a/utils/validators.js
+++ b/utils/validators.js
@@ -1,3 +1,5 @@
+/* eslint-disable consistent-return */
+
 'use strict';
 
 const { AuthenticationError } = require('apollo-server-express');
@@ -103,33 +105,43 @@ module.exports = {
       options.paranoid = false;
     }
 
-    if (params.pinType === 'CCP') {
-      if (!params.ccpParentId) {
+    if (params.args.pinType === 'CCP') {
+      if (!params.args.ccpId) {
         throw new Error('A CCP pin must be created by a valid CCP');
+      } else {
+        db.collectionPoint.findByPk(params.args.ccpId, options).then((ccp) => {
+          if (!ccp) {
+            throw new Error('Invalid CCP pin: ', params.args.ccpId);
+          }
+        })
       }
     }
 
-    if (params.pinType === 'EVENT') {
-      if (!params.eventId) {
+    if (params.args.pinType === 'EVENT') {
+      if (!params.args.eventId) {
         throw new Error('An event pin must be created by a valid event');
       }
 
-      if (params.ccpParentId) {
+      if (params.args.ccpId) {
         throw new Error('An event pin cannot be created by a CCP');
       }
     }
 
-    if (!params.newPin) {
+    if (params.args.pinType === 'OTHER') {
+      if (params.args.ccpId) {
+        throw new Error('An event pin cannot be created by a CCP');
+      }
+    }
+
+    if (params.args.id) {
       return db.locationPins
-        .findByPk(params.locationPinId, options)
+        .findByPk(params.args.id, options)
         .then((locationPin) => {
           if (!locationPin) {
-            throw new Error(params.errorMessage);
+            throw new Error('Invalid location pin ID: ' + params.args.id);
           }
         });
     }
-
-    return true;
   },
   validateRole: (
     role,

--- a/utils/validators.js
+++ b/utils/validators.js
@@ -106,7 +106,7 @@ module.exports = {
     checkParanoid = false,
     errorMessage = 'Invalid location pin ID: ' + locationPinId
   ) => {
-    console.log(pinType);
+
     const options = { paranoid: true };
     if (checkParanoid) {
       options.paranoid = false;
@@ -135,7 +135,7 @@ module.exports = {
         throw new Error('An event pin cannot be created by a CCP');
       }
     }
-    
+
     if(!newPin) {
       return db.locationPins
       .findByPk(locationPinId, options)

--- a/utils/validators.js
+++ b/utils/validators.js
@@ -1,5 +1,3 @@
-/* eslint-disable consistent-return */
-
 'use strict';
 
 const { AuthenticationError } = require('apollo-server-express');
@@ -13,11 +11,8 @@ module.exports = {
     checkParanoid = false,
     errorMessage = 'Invalid user ID: ' + userId
   ) => {
-    const options = { paranoid: true };
-    if (checkParanoid) {
-      options.paranoid = false;
-    }
-    return db.user.findByPk(userId, options).then((user) => {
+    // if checkParanoid is TRUE, we want to turn OFF the paranoid check in sequelize options
+    db.user.findByPk(userId, { paranoid: !checkParanoid }).then((user) => {
       if (!user) {
         throw new Error(errorMessage);
       }
@@ -28,11 +23,7 @@ module.exports = {
     checkParanoid = false,
     errorMessage = 'Invalid event ID: ' + eventId
   ) => {
-    const options = { paranoid: true };
-    if (checkParanoid) {
-      options.paranoid = false;
-    }
-    return db.event.findByPk(eventId, options).then((event) => {
+    db.event.findByPk(eventId, { paranoid: !checkParanoid }).then((event) => {
       if (!event) {
         throw new Error(errorMessage);
       }
@@ -43,77 +34,65 @@ module.exports = {
     checkParanoid = false,
     errorMessage = 'Invalid CCP ID: ' + ccpId
   ) => {
-    const options = { paranoid: true };
-    if (checkParanoid) {
-      options.paranoid = false;
-    }
-    return db.collectionPoint.findByPk(ccpId, options).then((ccp) => {
-      if (!ccp) {
-        throw new Error(errorMessage);
-      }
-    });
+    db.collectionPoint
+      .findByPk(ccpId, { paranoid: !checkParanoid })
+      .then((ccp) => {
+        if (!ccp) {
+          throw new Error(errorMessage);
+        }
+      });
   },
   validateAmbulance: (
     ambulanceId,
     checkParanoid = false,
     errorMessage = 'Invalid ambulance ID: ' + ambulanceId
   ) => {
-    const options = { paranoid: true };
-    if (checkParanoid) {
-      options.paranoid = false;
-    }
-    return db.ambulance.findByPk(ambulanceId, options).then((ambulance) => {
-      if (!ambulance) {
-        throw new Error(errorMessage);
-      }
-    });
+    db.ambulance
+      .findByPk(ambulanceId, { paranoid: !checkParanoid })
+      .then((ambulance) => {
+        if (!ambulance) {
+          throw new Error(errorMessage);
+        }
+      });
   },
   validateHospital: (
     hospitalId,
     checkParanoid = false,
     errorMessage = 'Invalid hospital ID: ' + hospitalId
   ) => {
-    const options = { paranoid: true };
-    if (checkParanoid) {
-      options.paranoid = false;
-    }
-    return db.hospital.findByPk(hospitalId, options).then((hospital) => {
-      if (!hospital) {
-        throw new Error(errorMessage);
-      }
-    });
+    db.hospital
+      .findByPk(hospitalId, { paranoid: !checkParanoid })
+      .then((hospital) => {
+        if (!hospital) {
+          throw new Error(errorMessage);
+        }
+      });
   },
   validatePatient: (
     patientId,
     checkParanoid = false,
     errorMessage = 'Invalid patient ID: ' + patientId
   ) => {
-    const options = { paranoid: true };
-    if (checkParanoid) {
-      options.paranoid = false;
-    }
-    return db.patient.findByPk(patientId, options).then((patient) => {
-      if (!patient) {
-        throw new Error(errorMessage);
-      }
-    });
+    db.patient
+      .findByPk(patientId, { paranoid: !checkParanoid })
+      .then((patient) => {
+        if (!patient) {
+          throw new Error(errorMessage);
+        }
+      });
   },
   validateLocationPin: (params) => {
-    const options = { paranoid: true };
-
-    if (params.checkParanoid) {
-      options.paranoid = false;
-    }
-
     if (params.args.pinType === 'CCP') {
       if (!params.args.ccpId) {
         throw new Error('A CCP pin must be created by a valid CCP');
       } else {
-        db.collectionPoint.findByPk(params.args.ccpId, options).then((ccp) => {
-          if (!ccp) {
-            throw new Error('Invalid CCP pin: ', params.args.ccpId);
-          }
-        })
+        db.collectionPoint
+          .findByPk(params.args.ccpId, { paranoid: !params.checkParanoid })
+          .then((ccp) => {
+            if (!ccp) {
+              throw new Error('Invalid CCP pin: ', params.args.ccpId);
+            }
+          });
       }
     }
 
@@ -134,8 +113,8 @@ module.exports = {
     }
 
     if (params.args.id) {
-      return db.locationPins
-        .findByPk(params.args.id, options)
+      db.locationPins
+        .findByPk(params.args.id, { paranoid: !params.checkParanoid })
         .then((locationPin) => {
           if (!locationPin) {
             throw new Error('Invalid location pin ID: ' + params.args.id);


### PR DESCRIPTION
[Notion ticket](https://www.notion.so/uwblueprintexecs/396370c5e09f4c28bc7f455a7e84c908?v=3751aa62a2594c74b7e0ecb363304c24&p=380f161e725846019b6d5002e046ff7c)

## Changes
- Added two new columns:
    - `pinType`: This is an enum column which indicates if a pin is an event, CCP or an 'other' pin
    - `ccpId`: This is a column to indicate the associated CCP for a CCP pin
- New validation:
    - If `pinType = EVENT`, then we want to make sure that the event given for a pin is valid and that `ccpParentId` is not filled
    - If `pinType = CCP`, then we want to make sure that a valid CCP is given

## Screenshots
<img width="1008" alt="Screen Shot 2020-11-30 at 1 33 39 PM" src="https://user-images.githubusercontent.com/21224282/100661406-a96e3f00-3310-11eb-9ff4-462339229da6.png">
<img width="989" alt="Screen Shot 2020-11-30 at 1 33 54 PM" src="https://user-images.githubusercontent.com/21224282/100661434-b25f1080-3310-11eb-9081-c574ac4f61fc.png">

## Testing
For each of the following, make sure that the database is reflected properly
- Add multiple event, CCPs and other pins 
- Edit multiple event, CCPs and other pins
- Delete and restore multiple event, CCP and other pins

## Checklist
>[Code review doc for reference](https://www.notion.so/uwblueprintexecs/Code-Review-a21fc85b00394f488e92d9d605f6b2bc)

before opening PR
- [x] check notion ticket
- [x] run linter
- [x] go through file diff

filling out PR
- [x] descriptive title
- [x] update `notion ticket` link
- [x] fill out `Changes`
  - [x] \(optional) add inline comments in diff
- [x] fill out `Testing`
- [x] \(optional) add `Screenshots`
- [x] assign yourself to the PR

after opening PR
- [x] link PR to notion ticket
- [x] move ticket to `In PR`
- [x] make sure build passes
- [x] ping `@ps` in `#paramedics-dev`
