### PR TITLE
Cascade deletion of location pins

### DIFF
--- a/models/collectionPoint.js
+++ b/models/collectionPoint.js
@@ -15,17 +15,28 @@ module.exports = (sequelize, DataTypes) => {
           instance
             .getPatients()
             .then((patients) => patients.map((patient) => patient.destroy()));
+
+          instance.getLocationPin().then((pin) => pin.destroy());
         },
         afterRestore: (instance) => {
           instance
             .getPatients({ paranoid: false })
             .then((patients) => patients.map((patient) => patient.restore()));
+          instance
+            .getLocationPin({ paranoid: false })
+            .then((pin) => pin.restore());
         },
       },
     }
   );
   collectionPoint.associate = (models) => {
     collectionPoint.hasMany(models.patient, {
+      hooks: true,
+    });
+
+    collectionPoint.hasOne(models.locationPins, {
+      foreignKey: 'ccpId',
+      targetKey: 'id',
       hooks: true,
     });
 

--- a/models/event.js
+++ b/models/event.js
@@ -19,6 +19,10 @@ module.exports = (sequelize, DataTypes) => {
                 collectionPoint.destroy()
               )
             );
+
+          instance
+            .getLocationPins()
+            .then((pins) => pins.map((pin) => pin.destroy()));
         },
         afterRestore: (instance) => {
           instance
@@ -28,12 +32,20 @@ module.exports = (sequelize, DataTypes) => {
                 collectionPoint.restore()
               )
             );
+
+          instance
+            .getLocationPins({ paranoid: false })
+            .then((pins) => pins.map((pin) => pin.restore()));
         },
       },
     }
   );
   Event.associate = (models) => {
     Event.hasMany(models.collectionPoint, {
+      hooks: true,
+    });
+
+    Event.hasMany(models.locationPins, {
       hooks: true,
     });
 

--- a/server.js
+++ b/server.js
@@ -9,11 +9,15 @@ const SESSION_SECRET = 'notsecure';
 
 const PORT = 4000;
 
-const hostUrl = process.env.REACT_APP_BACKEND_HOST || `http://localhost:${PORT}`;
+const hostUrl =
+  process.env.REACT_APP_BACKEND_HOST || `http://localhost:${PORT}`;
 let webSocketUrl = `ws://localhost:${PORT}/graphql`;
 if (process.env.REACT_APP_BACKEND_WEBSOCKET_URL) {
   if (process.env.REACT_APP_BACKEND_WEBSOCKET_URL === '/') {
-    const url = new URL(process.env.REACT_APP_BACKEND_WEBSOCKET_URL, window.location.href);
+    const url = new URL(
+      process.env.REACT_APP_BACKEND_WEBSOCKET_URL,
+      window.location.href
+    );
     webSocketUrl = url.protocol.replace('http', 'ws');
   } else {
     webSocketUrl = process.env.REACT_APP_BACKEND_WEBSOCKET_URL;


### PR DESCRIPTION
## Changes
- On deletion and restoration of event/CCP, any associated location pins should also be deleted and restored 

## Screenshots

## Testing
If you are at all confused about my implementation, [check out the docs I wrote a while back (and saved hours of my time)](https://www.notion.so/uwblueprintexecs/Paranoid-Tables-4fabc50d4a9b4c969c96d7ae5bc19cfc#7160023f3fd2402c8b695bace375dc20)

- Create an event, create some pins linked to the event (of all pin types, which are `OTHER`, `EVENT` and `CCP`), delete and restore the event. Check to make sure that associated pins are also deleted and restored and non-associated pins are unaffected
- Do the above but delete and restore collection points
- Make sure regular event, CCP and pin querying works

## Checklist
>[Code review doc for reference](https://www.notion.so/uwblueprintexecs/Code-Review-a21fc85b00394f488e92d9d605f6b2bc)

before opening PR
- [ ] check notion ticket
- [x] run linter
- [x] go through file diff

filling out PR
- [x] descriptive title
- [ ] update `notion ticket` link
- [x] fill out `Changes`
  - [ ] \(optional) add inline comments in diff
- [x] fill out `Testing`
- [ ] \(optional) add `Screenshots`
- [x] assign yourself to the PR

after opening PR
- [ ] link PR to notion ticket
- [ ] move ticket to `In PR`
- [ ] make sure build passes
- [x] ping `@ps` in `#paramedics-dev`
